### PR TITLE
[#340] WIP: proxy the jolokia api server

### DIFF
--- a/bridge-auth-http/.gitignore
+++ b/bridge-auth-http/.gitignore
@@ -1,0 +1,3 @@
+ca.crt
+ca-bundle.crt
+console-client-secret

--- a/bridge-auth-http/console-oauth-client.yaml
+++ b/bridge-auth-http/console-oauth-client.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: console-oauth-client-http
+parameters:
+  - name: OAUTH_SECRET
+    generate: expression
+    from: "[a-zA-Z0-9]{40}"
+  - name: REDIRECT_URL
+    value: http://localhost:9000/auth/callback
+    required: true
+objects:
+  - apiVersion: oauth.openshift.io/v1
+    kind: OAuthClient
+    metadata:
+      name: console-oauth-client-http
+    grantMethod: auto
+    secret: ${OAUTH_SECRET}
+    redirectURIs:
+    - ${REDIRECT_URL}

--- a/bridge-auth-http/sa-secrets.yaml
+++ b/bridge-auth-http/sa-secrets.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: builder-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: builder
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: default
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deployer-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: deployer
+type: kubernetes.io/service-account-token

--- a/bridge-auth-http/setup.sh
+++ b/bridge-auth-http/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+oc process -f console-oauth-client.yaml | oc apply -f -
+oc get oauthclient console-oauth-client-http -o jsonpath='{.secret}' > console-client-secret
+oc apply -f sa-secrets.yaml
+oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
+    jq '.items[0].data."ca.crt"' -r | python -m base64 -d > ca.crt
+oc extract cm/kube-apiserver-server-ca -n openshift-kube-apiserver --confirm

--- a/bridge-auth-https/.gitignore
+++ b/bridge-auth-https/.gitignore
@@ -1,0 +1,3 @@
+ca.crt
+ca-bundle.crt
+console-client-secret

--- a/bridge-auth-https/console-oauth-client.yaml
+++ b/bridge-auth-https/console-oauth-client.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: console-oauth-client-https
+parameters:
+  - name: OAUTH_SECRET
+    generate: expression
+    from: "[a-zA-Z0-9]{40}"
+  - name: REDIRECT_URL
+    value: https://localhost:9442/auth/callback
+    required: true
+objects:
+  - apiVersion: oauth.openshift.io/v1
+    kind: OAuthClient
+    metadata:
+      name: console-oauth-client-https
+    grantMethod: auto
+    secret: ${OAUTH_SECRET}
+    redirectURIs:
+    - ${REDIRECT_URL}

--- a/bridge-auth-https/sa-secrets.yaml
+++ b/bridge-auth-https/sa-secrets.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: builder-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: builder
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: default
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deployer-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: deployer
+type: kubernetes.io/service-account-token

--- a/bridge-auth-https/setup.sh
+++ b/bridge-auth-https/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+oc process -f console-oauth-client.yaml | oc apply -f -
+oc get oauthclient console-oauth-client-https -o jsonpath='{.secret}' > console-client-secret
+oc apply -f sa-secrets.yaml
+oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
+    jq '.items[0].data."ca.crt"' -r | python -m base64 -d > ca.crt
+oc extract cm/kube-apiserver-server-ca -n openshift-kube-apiserver --confirm

--- a/deploy/base/plugin.yaml
+++ b/deploy/base/plugin.yaml
@@ -16,6 +16,7 @@ spec:
   proxy:
     - type: Service
       alias: api-server-service
+      authorization: UserToken
       endpoint:
         type: Service
         service:

--- a/src/brokers/broker-details/components/JolokiaDevComponents.tsx
+++ b/src/brokers/broker-details/components/JolokiaDevComponents.tsx
@@ -50,13 +50,11 @@ function getApiHost(): string {
 }
 
 function getApiPort(): string {
-  return process.env.NODE_ENV === 'production' ? '443' : '9443';
+  return process.env.NODE_ENV === 'production' ? '443' : '9442';
 }
 
 function getProxyUrl(): string {
-  return process.env.NODE_ENV === 'production'
-    ? '/api/proxy/plugin/activemq-artemis-self-provisioning-plugin/api-server-service'
-    : '';
+  return '/api/proxy/plugin/activemq-artemis-self-provisioning-plugin/api-server-service';
 }
 
 type SignatureSubFormType = {

--- a/src/jolokia/customHooks.ts
+++ b/src/jolokia/customHooks.ts
@@ -247,14 +247,12 @@ export const useJolokiaLogin = (
 };
 
 function getProxyUrl(): string {
-  return process.env.NODE_ENV === 'production'
-    ? '/api/proxy/plugin/activemq-artemis-self-provisioning-plugin/api-server-service'
-    : '';
+  return '/api/proxy/plugin/activemq-artemis-self-provisioning-plugin/api-server-service';
 }
 
 export const useGetApiServerBaseUrl = (): string => {
   let apiHost = 'localhost';
-  let apiPort = '9443';
+  let apiPort = '9442';
   if (process.env.NODE_ENV === 'production') {
     apiHost = location.hostname;
     apiPort = '443';

--- a/start-console-tls.sh
+++ b/start-console-tls.sh
@@ -11,10 +11,23 @@ PLUGIN_NAME=${npm_package_consolePlugin_name}
 
 echo "Starting local OpenShift console in https mode..."
 
+BRIDGE_BASE_ADDRESS="https://localhost:${CONSOLE_PORT}"
+
 BRIDGE_LISTEN="https://0.0.0.0:${CONSOLE_PORT}"
 BRIDGE_TLS_CERT_FILE=/console-cert/domain.crt
 BRIDGE_TLS_KEY_FILE=/console-cert/domain.key
-BRIDGE_USER_AUTH="disabled"
+
+## disable auth
+#BRIDGE_USER_AUTH="disabled"
+#BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+
+# authenticating the console
+BRIDGE_USER_AUTH="openshift"
+BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client-https"
+BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE="/bridge-auth-https/console-client-secret"
+BRIDGE_USER_AUTH_OIDC_CA_FILE="/bridge-auth-https/ca.crt"
+BRIDGE_CA_FILE="/bridge-auth-https/ca-bundle.crt"
+
 BRIDGE_K8S_MODE="off-cluster"
 BRIDGE_K8S_AUTH="bearer-token"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
@@ -24,7 +37,6 @@ set +e
 BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}' 2>/dev/null)
 BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}' 2>/dev/null)
 set -e
-BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 BRIDGE_I18N_NAMESPACES="plugin__${PLUGIN_NAME}"
 
@@ -36,6 +48,12 @@ if [ -n "$GITOPS_HOSTNAME" ]; then
     BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS="https://$GITOPS_HOSTNAME"
 fi
 
+function getBridgePluginProxy {
+    local host='localhost'
+    local endpoint="https://${host}:9443"
+    echo "{\"services\": [{\"consoleAPIPath\": \"/api/proxy/plugin/activemq-artemis-self-provisioning-plugin/api-server-service/\", \"endpoint\":\"${endpoint}\",\"authorize\":true}]}"
+}
+
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
 echo "Console URL: https://localhost:${CONSOLE_PORT}"
@@ -45,13 +63,36 @@ echo "Console Platform: $CONSOLE_IMAGE_PLATFORM"
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=https://localhost:9444"
-        podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm -v ./console-cert:/console-cert:z --rm --network=host --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+        podman run --pull always \
+            --platform $CONSOLE_IMAGE_PLATFORM \
+            --rm -v ./bridge-auth-https:/bridge-auth-https:z \
+            --rm -v ./console-cert:/console-cert:z \
+            --rm --network=host \
+            --env-file <(set | grep BRIDGE) \
+            --env BRIDGE_PLUGINS="${PLUGIN_NAME}=https://localhost:9444" \
+            --env BRIDGE_PLUGIN_PROXY="$(getBridgePluginProxy)" \
+            $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=https://host.containers.internal:9444"
-        podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm -v ./console-cert:/console-cert:z --rm -p "$CONSOLE_PORT":9442 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+        podman run \
+            --pull always \
+            --platform $CONSOLE_IMAGE_PLATFORM \
+            --rm -v ./bridge-auth-https:/bridge-auth-https:z \
+            --rm -v ./console-cert:/console-cert:z \
+            --rm -p "$CONSOLE_PORT":9442 \
+            --env-file <(set | grep BRIDGE) \
+            --env BRIDGE_PLUGINS="${PLUGIN_NAME}=https://host.containers.localhost:9444" \
+            --env BRIDGE_PLUGIN_PROXY="$(getBridgePluginProxy)" \
+            $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${PLUGIN_NAME}=https://host.containers.internal:9444"
-    docker run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm -p "$CONSOLE_PORT":9442 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+    docker run \
+        --pull always \
+        --platform $CONSOLE_IMAGE_PLATFORM \
+        --rm -v ./bridge-auth-http:/bridge-auth-http:z \
+        --rm -v ./console-cert:/console-cert:z \
+        --rm -p "$CONSOLE_PORT":9442 \
+        --env-file <(set | grep BRIDGE) \
+        --env BRIDGE_PLUGINS="${PLUGIN_NAME}=https://host.docker.internal:9444" \
+        --env BRIDGE_PLUGIN_PROXY="$(getBridgePluginProxy)" \
+        $CONSOLE_IMAGE
 fi

--- a/start-console.sh
+++ b/start-console.sh
@@ -11,7 +11,19 @@ PLUGIN_NAME=${npm_package_consolePlugin_name}
 
 echo "Starting local OpenShift console..."
 
-BRIDGE_USER_AUTH="disabled"
+BRIDGE_BASE_ADDRESS="http://localhost:${CONSOLE_PORT}"
+
+## disable auth
+#BRIDGE_USER_AUTH="disabled"
+#BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+
+# authenticating the console
+BRIDGE_USER_AUTH="openshift"
+BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client-http"
+BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE="/bridge-auth-http/console-client-secret"
+BRIDGE_USER_AUTH_OIDC_CA_FILE="/bridge-auth-http/ca.crt"
+BRIDGE_CA_FILE="/bridge-auth-http/ca-bundle.crt"
+
 BRIDGE_K8S_MODE="off-cluster"
 BRIDGE_K8S_AUTH="bearer-token"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
@@ -21,7 +33,6 @@ set +e
 BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}' 2>/dev/null)
 BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}' 2>/dev/null)
 set -e
-BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 BRIDGE_I18N_NAMESPACES="plugin__${PLUGIN_NAME}"
 
@@ -33,6 +44,12 @@ if [ -n "$GITOPS_HOSTNAME" ]; then
     BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS="https://$GITOPS_HOSTNAME"
 fi
 
+function getBridgePluginProxy {
+    local host='localhost'
+    local endpoint="https://${host}:9443"
+    echo "{\"services\": [{\"consoleAPIPath\": \"/api/proxy/plugin/activemq-artemis-self-provisioning-plugin/api-server-service/\", \"endpoint\":\"${endpoint}\",\"authorize\":true}]}"
+}
+
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
 echo "Console URL: http://localhost:${CONSOLE_PORT}"
@@ -42,13 +59,34 @@ echo "Console Platform: $CONSOLE_IMAGE_PLATFORM"
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001"
-        podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm --network=host --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+        podman run \
+            --pull always \
+            --platform $CONSOLE_IMAGE_PLATFORM \
+            --rm -v ./bridge-auth-http:/bridge-auth-http:z \
+            --rm --network=host \
+            --env-file <(set | grep BRIDGE) \
+            --env BRIDGE_PLUGINS="${PLUGIN_NAME}=http://localhost:9001" \
+            --env BRIDGE_PLUGIN_PROXY="$(getBridgePluginProxy)" \
+            $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
-        podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+        podman run \
+            --pull always \
+            --platform $CONSOLE_IMAGE_PLATFORM \
+            --rm -v ./bridge-auth-http:/bridge-auth-http:z \
+            --rm -p "$CONSOLE_PORT":9000 \
+            --env-file <(set | grep BRIDGE) \
+            --env BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.localhost:9001" \
+            --env BRIDGE_PLUGIN_PROXY="$(getBridgePluginProxy)" \
+            $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001"
-    docker run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+    docker run \
+        --pull always \
+        --platform $CONSOLE_IMAGE_PLATFORM \
+        --rm -v ./bridge-auth-http:/bridge-auth-http:z \
+        --rm -p "$CONSOLE_PORT":9000 \
+        --env-file <(set | grep BRIDGE) \
+        --env BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.docker.internal:9001" \
+        --env BRIDGE_PLUGIN_PROXY="$(getBridgePluginProxy)" \
+        $CONSOLE_IMAGE
 fi


### PR DESCRIPTION
In order to get authenticated as a user using the jolokia api server, we need to set up proxies. The console will take care of adding the authorization bearer token on every requests for us.

This commit adds the configuration for running both in dev mode and production mode.


Todo list:

- [ ] integrate with a newer version of the jolokia api server that is able to understand the bearer token and remove the need of login.