### PR TITLE
[#26] reducer: a 7.13 reducer to host new changes

### DIFF
--- a/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
+++ b/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
@@ -192,7 +192,7 @@
   "SSL Enabled for console": "SSL Enabled for console",
   "CR Name": "CR Name",
   "Replicas": "Replicas",
-  "Broker Properties": "Broker Properties",
+  "Broker Version": "Broker Version",
   "Per broker config": "Per broker config",
   " in namespace ": " in namespace ",
   "Save and proceed": "Save and proceed",

--- a/src/brokers/add-broker/AddBroker.component.test.tsx
+++ b/src/brokers/add-broker/AddBroker.component.test.tsx
@@ -3,8 +3,8 @@ import {
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
   artemisCrReducer,
-  newArtemisCRState,
-} from '../../reducers/7.12/reducer';
+  newArtemisCR,
+} from '@app/reducers/reducer';
 import { fireEvent, render, screen } from '../../test-utils';
 import { AddBroker } from './AddBroker.component';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
@@ -22,7 +22,7 @@ const SimplifiedCreaterBrokerPage: FC = () => {
   const onCancel = () => {
     return 0;
   };
-  const initialValues = newArtemisCRState('default');
+  const initialValues = newArtemisCR('default');
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
   return (
     <BrokerCreationFormState.Provider value={brokerModel}>
@@ -43,7 +43,7 @@ const SimplifiedUpdateBrokerPage: FC = () => {
   const reloadExisting = () => {
     return 0;
   };
-  const initialValues = newArtemisCRState('default');
+  const initialValues = newArtemisCR('default');
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
   return (
     <BrokerCreationFormState.Provider value={brokerModel}>

--- a/src/brokers/add-broker/AddBroker.component.tsx
+++ b/src/brokers/add-broker/AddBroker.component.tsx
@@ -12,11 +12,11 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 import {
-  ArtemisReducerOperations,
+  ArtemisReducerGlobalOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
   EditorType,
-} from '../../reducers/7.12/reducer';
+} from '@app/reducers/reducer';
 import { FormView } from '../../shared-components/FormView/FormView';
 import { EditorToggle } from './components/EditorToggle/EditorToggle';
 import { Loading } from '../../shared-components/Loading/Loading';
@@ -57,7 +57,7 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
       setPendingActionQuittingYAMLView('switch');
     } else {
       dispatch({
-        operation: ArtemisReducerOperations.setEditorType,
+        operation: ArtemisReducerGlobalOperations.setEditorType,
         payload: EditorType.YAML,
       });
     }
@@ -69,7 +69,7 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
     if (pendingActionQuittingYAMLView === 'switch') {
       setWantsToQuitYamlView(false);
       dispatch({
-        operation: ArtemisReducerOperations.setEditorType,
+        operation: ArtemisReducerGlobalOperations.setEditorType,
         payload: EditorType.BROKER,
       });
     }

--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -5,25 +5,25 @@ import { AddBroker } from './AddBroker.component';
 import { AMQBrokerModel } from '@app/k8s/models';
 import { BrokerCR } from '@app/k8s/types';
 import {
-  BrokerCreationFormState,
   BrokerCreationFormDispatch,
-  newArtemisCRState,
+  BrokerCreationFormState,
   artemisCrReducer,
-  ArtemisReducerOperations,
-} from '@app/reducers/7.12/reducer';
-import { AddBrokerResourceValues } from '@app/reducers/7.12/import-types';
+  newArtemisCR,
+} from '@app/reducers/reducer';
+import { ArtemisReducerOperations712 } from '@app/reducers/7.12/reducer';
+import { FormState712 } from '@app/reducers/7.12/import-types';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useGetIngressDomain } from '@app/k8s/customHooks';
 
 export interface AddBrokerProps {
-  initialValues: AddBrokerResourceValues;
+  initialValues: FormState712;
 }
 
 export const AddBrokerPage: FC = () => {
   const navigate = useNavigate();
   const { ns: namespace } = useParams<{ ns?: string }>();
 
-  const initialValues = newArtemisCRState(namespace);
+  const initialValues = newArtemisCR(namespace);
 
   //states
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
@@ -62,7 +62,7 @@ export const AddBrokerPage: FC = () => {
   const [prevNamespace, setPrevNamespace] = useState(namespace);
   if (prevNamespace !== namespace) {
     dispatch({
-      operation: ArtemisReducerOperations.setNamespace,
+      operation: ArtemisReducerOperations712.setNamespace,
       payload: namespace,
     });
     setPrevNamespace(namespace);
@@ -72,7 +72,7 @@ export const AddBrokerPage: FC = () => {
   const [isDomainSet, setIsDomainSet] = useState(false);
   if (!isLoading && !isDomainSet) {
     dispatch({
-      operation: ArtemisReducerOperations.setIngressDomain,
+      operation: ArtemisReducerOperations712.setIngressDomain,
       payload: {
         ingressUrl: clusterDomain,
         isSetByUser: false,

--- a/src/brokers/add-broker/components/EditorToggle/EditorToggle.tsx
+++ b/src/brokers/add-broker/components/EditorToggle/EditorToggle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Flex, Radio } from '@patternfly/react-core';
 import { useTranslation } from '@app/i18n/i18n';
-import { EditorType } from '@app/reducers/7.12/reducer';
+import { EditorType } from '@app/reducers/reducer';
 
 type EditorToggleProps = {
   value: EditorType;

--- a/src/brokers/update-broker/UpdateBroker.container.tsx
+++ b/src/brokers/update-broker/UpdateBroker.container.tsx
@@ -7,12 +7,13 @@ import { AMQBrokerModel } from '@app/k8s/models';
 import { BrokerCR } from '@app/k8s/types';
 import { useGetIngressDomain } from '@app/k8s/customHooks';
 import {
-  ArtemisReducerOperations,
+  ArtemisReducerGlobalOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
   artemisCrReducer,
-  getArtemisCRState,
-} from '@app/reducers/7.12/reducer';
+  newArtemisCR,
+} from '@app/reducers/reducer';
+import { ArtemisReducerOperations712 } from '@app/reducers/7.12/reducer';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 
 export const UpdateBrokerPage: FC = () => {
@@ -22,9 +23,10 @@ export const UpdateBrokerPage: FC = () => {
   //states
   const [loadingBrokerCR, setLoading] = useState<boolean>(false);
 
-  const crState = getArtemisCRState(name, namespace);
-
-  const [brokerModel, dispatch] = useReducer(artemisCrReducer, crState);
+  const [brokerModel, dispatch] = useReducer(
+    artemisCrReducer,
+    newArtemisCR(namespace),
+  );
 
   const [hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
   const [alert, setAlert] = useState('');
@@ -59,7 +61,7 @@ export const UpdateBrokerPage: FC = () => {
     k8sGet({ model: AMQBrokerModel, name, ns: namespace })
       .then((broker: BrokerCR) => {
         dispatch({
-          operation: ArtemisReducerOperations.setModel,
+          operation: ArtemisReducerGlobalOperations.setModel,
           payload: { model: broker, isSetByUser: false },
         });
       })
@@ -80,7 +82,7 @@ export const UpdateBrokerPage: FC = () => {
   const [isDomainSet, setIsDomainSet] = useState(false);
   if (!loadingBrokerCR && !isLoadingClusterDomain && !isDomainSet) {
     dispatch({
-      operation: ArtemisReducerOperations.setIngressDomain,
+      operation: ArtemisReducerOperations712.setIngressDomain,
       payload: {
         ingressUrl: clusterDomain,
         isSetByUser: false,
@@ -91,7 +93,7 @@ export const UpdateBrokerPage: FC = () => {
 
   if (loadingBrokerCR && !alert) return <Loading />;
 
-  if (!brokerModel.cr.spec?.deploymentPlan) {
+  if (!brokerModel.cr?.spec?.deploymentPlan) {
     return <Loading />;
   }
 

--- a/src/reducers/7.12/import-types.ts
+++ b/src/reducers/7.12/import-types.ts
@@ -1,7 +1,7 @@
 import { BrokerCR } from '@app/k8s/types';
-import { EditorType } from './reducer';
+import { BaseFormState, EditorType } from '../reducer';
 
-export interface AddBrokerResourceValues {
+export interface FormState712 extends BaseFormState {
   shouldShowYAMLMessage?: boolean;
   editorType?: EditorType;
   yamlHasUnsavedChanges?: boolean;

--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -1,10 +1,9 @@
 import { SelectOptionObject } from '@patternfly/react-core/deprecated';
 import {
-  ArtemisReducerOperations,
-  EditorType,
+  ArtemisReducerOperations712,
   ExposeMode,
-  artemisCrReducer,
-  newArtemisCRState,
+  reducer712,
+  newBroker712CR,
 } from './reducer';
 
 describe('test the creation broker reducer', () => {
@@ -16,9 +15,9 @@ describe('test the creation broker reducer', () => {
     };
   };
   it('test addAcceptor', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newState.cr.spec.acceptors).toHaveLength(1);
     expect(newState.cr.spec.acceptors[0].name).toBe('acceptors0');
@@ -31,9 +30,9 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test addConnector', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newState.cr.spec.connectors).toHaveLength(1);
     expect(newState.cr.spec.connectors[0].name).toBe('connectors0');
@@ -46,54 +45,54 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test replicas decrementReplicas', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.decrementReplicas,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.decrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 0
     expect(newState.cr.spec.deploymentPlan.size).toBe(0);
     // set the number of replicas to 10 before decrementing so that the total
     // number should be 9
-    const newState2 = artemisCrReducer(
-      artemisCrReducer(newState, {
-        operation: ArtemisReducerOperations.setReplicasNumber,
+    const newState2 = reducer712(
+      reducer712(newState, {
+        operation: ArtemisReducerOperations712.setReplicasNumber,
         payload: 10,
       }),
       {
-        operation: ArtemisReducerOperations.decrementReplicas,
+        operation: ArtemisReducerOperations712.decrementReplicas,
       },
     );
     expect(newState2.cr.spec.deploymentPlan.size).toBe(9);
   });
 
   it('tests that the deployment replicas value cannot be decremented below 0', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.decrementReplicas,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.decrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 0
     expect(newState.cr.spec.deploymentPlan.size).toBe(0);
     // Set the number of replicas to -1 and verify that the deployment replicas value cannot be decremented below 0.
     // The number should be set to 0.
-    const newState2 = artemisCrReducer(
-      artemisCrReducer(newState, {
-        operation: ArtemisReducerOperations.setReplicasNumber,
+    const newState2 = reducer712(
+      reducer712(newState, {
+        operation: ArtemisReducerOperations712.setReplicasNumber,
         payload: -1,
       }),
       {
-        operation: ArtemisReducerOperations.decrementReplicas,
+        operation: ArtemisReducerOperations712.decrementReplicas,
       },
     );
     expect(newState2.cr.spec.deploymentPlan.size).toBe(0);
   });
 
   it('test deleteAcceptor', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.deleteAcceptor,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.deleteAcceptor,
       payload: 'acceptors0',
     });
     expect(newState2.cr.spec.acceptors).toHaveLength(0);
@@ -103,12 +102,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test deleteConnector', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.deleteConnector,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.deleteConnector,
       payload: 'connectors0',
     });
     expect(newState2.cr.spec.connectors).toHaveLength(0);
@@ -118,41 +117,41 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test incrementReplicas', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.incrementReplicas,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.incrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 1
     expect(newState.cr.spec.deploymentPlan.size).toBe(2);
   });
 
   it('test incrementReplicas', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.incrementReplicas,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.incrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 1
     expect(newState.cr.spec.deploymentPlan.size).toBe(2);
   });
 
   it('test setAcceptorBindToAllInterfaces', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(stateWith1Acceptor.cr.spec.acceptors[0].bindToAllInterfaces).toBe(
       undefined,
     );
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorBindToAllInterfaces,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorBindToAllInterfaces,
       payload: {
         name: 'acceptors0',
         bindToAllInterfaces: true,
       },
     });
     expect(newState2.cr.spec.acceptors[0].bindToAllInterfaces).toBe(true);
-    const newState3 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorBindToAllInterfaces,
+    const newState3 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorBindToAllInterfaces,
       payload: {
         name: 'acceptors0',
         bindToAllInterfaces: false,
@@ -162,12 +161,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setAcceptorName', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorName,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorName,
       payload: {
         oldName: 'acceptors0',
         newName: 'superName',
@@ -180,15 +179,15 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test renaming an acceptor to an existing name to have no effect', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateWith2Acceptor = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const stateWith2Acceptor = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState3 = artemisCrReducer(stateWith2Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorName,
+    const newState3 = reducer712(stateWith2Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorName,
       payload: {
         oldName: 'acceptors1',
         newName: 'acceptors0',
@@ -199,12 +198,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setAcceptorOtherParams', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorOtherParams,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorOtherParams,
       payload: {
         name: 'acceptors0',
         otherParams: new Map<string, string>([
@@ -219,8 +218,8 @@ describe('test the creation broker reducer', () => {
     expect(newState2.cr.spec.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.params.bKey=bValue',
     );
-    const newState3 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.setAcceptorOtherParams,
+    const newState3 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.setAcceptorOtherParams,
       payload: {
         name: 'acceptors0',
         otherParams: new Map<string, string>([['aKey', 'aValue']]),
@@ -235,34 +234,34 @@ describe('test the creation broker reducer', () => {
   });
 
   it('should assigns unique ports to each new acceptor added', () => {
-    const initialState = newArtemisCRState('namespace');
+    const initialState = newBroker712CR('namespace');
 
     // Add the first acceptor
-    let newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    let newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newState.cr.spec.acceptors[0].port).toBe(5555);
 
     // Add a second acceptor
-    newState = artemisCrReducer(newState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    newState = reducer712(newState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newState.cr.spec.acceptors[1].port).toBe(5556);
 
     // Add a third acceptor
-    newState = artemisCrReducer(newState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    newState = reducer712(newState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newState.cr.spec.acceptors[2].port).toBe(5557);
   });
 
   it('test setAcceptorPort', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorPort,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorPort,
       payload: {
         name: 'acceptors0',
         port: 6666,
@@ -272,12 +271,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('should increments next acceptor port based on manually set port value', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    let newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorPort,
+    let newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorPort,
       payload: {
         name: 'acceptors0',
         port: 6666,
@@ -285,19 +284,19 @@ describe('test the creation broker reducer', () => {
     });
     expect(newState2.cr.spec.acceptors[0].port).toBe(6666);
 
-    newState2 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    newState2 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newState2.cr.spec.acceptors[1].port).toBe(6667);
   });
 
   it('test setAcceptorProtocols', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorProtocols,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorProtocols,
       payload: {
         configName: 'acceptors0',
         protocols: 'ALL,SOMETHING',
@@ -307,12 +306,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setAcceptorSSLEnabled', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorSSLEnabled,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorSSLEnabled,
       payload: {
         name: 'acceptors0',
         sslEnabled: true,
@@ -322,12 +321,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setAcceptorSecret', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorSecret,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorSecret,
       payload: {
         name: 'acceptors0',
         isCa: false,
@@ -335,8 +334,8 @@ describe('test the creation broker reducer', () => {
       },
     });
     expect(newState2.cr.spec.acceptors[0].sslSecret).toBe('toto');
-    const newState3 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.setAcceptorSecret,
+    const newState3 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.setAcceptorSecret,
       payload: {
         name: 'acceptors0',
         isCa: true,
@@ -347,9 +346,9 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setBrokerName', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setBrokerName,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setBrokerName,
       payload: 'newName',
     });
     expect(newState.cr.metadata.name).toBe('newName');
@@ -357,23 +356,23 @@ describe('test the creation broker reducer', () => {
 
   // enchaine avec le lwoercase
   it('test setConnectorBindToAllInterfaces', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(stateWith1Connector.cr.spec.connectors[0].bindToAllInterfaces).toBe(
       undefined,
     );
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorBindToAllInterfaces,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorBindToAllInterfaces,
       payload: {
         name: 'connectors0',
         bindToAllInterfaces: true,
       },
     });
     expect(newState2.cr.spec.connectors[0].bindToAllInterfaces).toBe(true);
-    const newState3 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorBindToAllInterfaces,
+    const newState3 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorBindToAllInterfaces,
       payload: {
         name: 'connectors0',
         bindToAllInterfaces: false,
@@ -383,12 +382,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConnectorHost', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorHost,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorHost,
       payload: {
         connectorName: 'connectors0',
         host: 'superHost',
@@ -398,12 +397,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConnectorName', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorName,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorName,
       payload: {
         oldName: 'connectors0',
         newName: 'superName',
@@ -416,15 +415,15 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test renaming an connector to an existing name to have no effect', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const stateWith2Connector = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.addConnector,
+    const stateWith2Connector = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState3 = artemisCrReducer(stateWith2Connector, {
-      operation: ArtemisReducerOperations.setConnectorName,
+    const newState3 = reducer712(stateWith2Connector, {
+      operation: ArtemisReducerOperations712.setConnectorName,
       payload: {
         oldName: 'connectors1',
         newName: 'connectors0',
@@ -435,12 +434,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConnectorOtherParams', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorOtherParams,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorOtherParams,
       payload: {
         name: 'connectors0',
         otherParams: new Map<string, string>([
@@ -455,8 +454,8 @@ describe('test the creation broker reducer', () => {
     expect(newState2.cr.spec.brokerProperties).toContain(
       'connectorConfigurations.connectors0.params.bKey=bValue',
     );
-    const newState3 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.setConnectorOtherParams,
+    const newState3 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.setConnectorOtherParams,
       payload: {
         name: 'connectors0',
         otherParams: new Map<string, string>([['aKey', 'aValue']]),
@@ -471,34 +470,34 @@ describe('test the creation broker reducer', () => {
   });
 
   it('should assigns unique ports to each new connector added', () => {
-    const initialState = newArtemisCRState('namespace');
+    const initialState = newBroker712CR('namespace');
 
     // Add the first connector
-    let newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    let newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newState.cr.spec.connectors[0].port).toBe(5555);
 
     // Add a second connector
-    newState = artemisCrReducer(newState, {
-      operation: ArtemisReducerOperations.addConnector,
+    newState = reducer712(newState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newState.cr.spec.connectors[1].port).toBe(5556);
 
     // Add a third connector
-    newState = artemisCrReducer(newState, {
-      operation: ArtemisReducerOperations.addConnector,
+    newState = reducer712(newState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newState.cr.spec.connectors[2].port).toBe(5557);
   });
 
   it('test setConnectorPort', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorPort,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorPort,
       payload: {
         name: 'connectors0',
         port: 6666,
@@ -508,12 +507,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('should increments next connector port based on manually set port value', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    let newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorPort,
+    let newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorPort,
       payload: {
         name: 'connectors0',
         port: 6666,
@@ -521,29 +520,29 @@ describe('test the creation broker reducer', () => {
     });
     expect(newState2.cr.spec.connectors[0].port).toBe(6666);
 
-    newState2 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.addConnector,
+    newState2 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newState2.cr.spec.connectors[1].port).toBe(6667);
   });
 
   it('test unique port allocation by combining both new added acceptors/connectors and verify correct port incrementation after manual port modification', () => {
-    const initialState = newArtemisCRState('namespace');
+    const initialState = newBroker712CR('namespace');
     //Add first acceptor
-    let newStateWithAcceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    let newStateWithAcceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newStateWithAcceptor.cr.spec.acceptors[0].port).toBe(5555);
 
     //Add second acceptor
-    newStateWithAcceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    newStateWithAcceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newStateWithAcceptor.cr.spec.acceptors[1].port).toBe(5556);
 
     // Manually change the port of the second acceptor to 5557
-    newStateWithAcceptor = artemisCrReducer(newStateWithAcceptor, {
-      operation: ArtemisReducerOperations.setAcceptorPort,
+    newStateWithAcceptor = reducer712(newStateWithAcceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorPort,
       payload: {
         name: 'acceptors1',
         port: 5557,
@@ -552,26 +551,26 @@ describe('test the creation broker reducer', () => {
     expect(newStateWithAcceptor.cr.spec.acceptors[1].port).toBe(5557);
 
     //Add third acceptor
-    newStateWithAcceptor = artemisCrReducer(newStateWithAcceptor, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    newStateWithAcceptor = reducer712(newStateWithAcceptor, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
     expect(newStateWithAcceptor.cr.spec.acceptors[2].port).toBe(5558);
 
     //Add first connector
-    let newStateWithConnector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    let newStateWithConnector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newStateWithConnector.cr.spec.connectors[0].port).toBe(5555);
 
     //Add second connector
-    newStateWithConnector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    newStateWithConnector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5556);
 
     // Manually change the port of the second connector to 5557
-    newStateWithConnector = artemisCrReducer(newStateWithConnector, {
-      operation: ArtemisReducerOperations.setConnectorPort,
+    newStateWithConnector = reducer712(newStateWithConnector, {
+      operation: ArtemisReducerOperations712.setConnectorPort,
       payload: {
         name: 'connectors1',
         port: 5557,
@@ -580,19 +579,19 @@ describe('test the creation broker reducer', () => {
     expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5557);
 
     //Add third connector
-    newStateWithConnector = artemisCrReducer(newStateWithConnector, {
-      operation: ArtemisReducerOperations.addConnector,
+    newStateWithConnector = reducer712(newStateWithConnector, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
     expect(newStateWithConnector.cr.spec.connectors[2].port).toBe(5558);
   });
 
   it('test setConnectorProtocols', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorProtocols,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorProtocols,
       payload: {
         configName: 'connectors0',
         protocols: 'ALL,SOMETHING',
@@ -602,12 +601,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConnectorSSLEnabled', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorSSLEnabled,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorSSLEnabled,
       payload: {
         name: 'connectors0',
         sslEnabled: true,
@@ -617,12 +616,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConnectorSecret', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Connector = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Connector = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Connector, {
-      operation: ArtemisReducerOperations.setConnectorSecret,
+    const newState2 = reducer712(stateWith1Connector, {
+      operation: ArtemisReducerOperations712.setConnectorSecret,
       payload: {
         name: 'connectors0',
         isCa: false,
@@ -630,8 +629,8 @@ describe('test the creation broker reducer', () => {
       },
     });
     expect(newState2.cr.spec.connectors[0].sslSecret).toBe('toto');
-    const newState3 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.setConnectorSecret,
+    const newState3 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.setConnectorSecret,
       payload: {
         name: 'connectors0',
         isCa: true,
@@ -642,9 +641,9 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConsoleCredentials', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setConsoleCredentials,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setConsoleCredentials,
       payload: {
         adminUser: 'some',
         adminPassword: 'thing',
@@ -655,36 +654,36 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setConsoleExpose', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setConsoleExpose,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setConsoleExpose,
       payload: true,
     });
     expect(newState.cr.spec.console.expose).toBe(true);
   });
 
   it('test setConsoleExposeMode', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setConsoleExposeMode,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setConsoleExposeMode,
       payload: ExposeMode.ingress,
     });
     expect(newState.cr.spec.console.exposeMode).toBe(ExposeMode.ingress);
   });
 
   it('test setConsoleSSLEnabled', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setConsoleSSLEnabled,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setConsoleSSLEnabled,
       payload: true,
     });
     expect(newState.cr.spec.console.sslEnabled).toBe(true);
   });
 
   it('test setConsoleSecret', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setConsoleSecret,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setConsoleSecret,
       payload: {
         name: 'console',
         isCa: true,
@@ -694,40 +693,31 @@ describe('test the creation broker reducer', () => {
     expect(newState.cr.spec.console.trustSecret).toBe('toto');
   });
 
-  it('test setEditorType', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setEditorType,
-      payload: EditorType.BROKER,
-    });
-    expect(newState.editorType).toBe(EditorType.BROKER);
-  });
-
   it('test setNamespace', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setNamespace,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setNamespace,
       payload: 'newNamespace',
     });
     expect(newState.cr.metadata.namespace).toBe('newNamespace');
   });
 
   it('test replicas setReplicasNumber', () => {
-    const initialState = newArtemisCRState('namespace');
-    const newState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setReplicasNumber,
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setReplicasNumber,
       payload: 10,
     });
     expect(newState.cr.spec.deploymentPlan.size).toBe(10);
   });
 
   it('test updateAcceptorFactoryClass', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.updateAcceptorFactoryClass,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.updateAcceptorFactoryClass,
       payload: {
         name: 'acceptors0',
         class: 'invm',
@@ -736,8 +726,8 @@ describe('test the creation broker reducer', () => {
     expect(newState2.cr.spec.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory',
     );
-    const newState3 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.updateAcceptorFactoryClass,
+    const newState3 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.updateAcceptorFactoryClass,
       payload: {
         name: 'acceptors0',
         class: 'netty',
@@ -749,12 +739,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test updateConnectorFactoryClass', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addConnector,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addConnector,
     });
-    const newState2 = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.updateConnectorFactoryClass,
+    const newState2 = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.updateConnectorFactoryClass,
       payload: {
         name: 'connectors0',
         class: 'invm',
@@ -763,8 +753,8 @@ describe('test the creation broker reducer', () => {
     expect(newState2.cr.spec.brokerProperties).toContain(
       'connectorConfigurations.connectors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory',
     );
-    const newState3 = artemisCrReducer(newState2, {
-      operation: ArtemisReducerOperations.updateConnectorFactoryClass,
+    const newState3 = reducer712(newState2, {
+      operation: ArtemisReducerOperations712.updateConnectorFactoryClass,
       payload: {
         name: 'connectors0',
         class: 'netty',
@@ -776,16 +766,16 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test activatePEMGenerationForAcceptor', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateWithIngressDomain = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setIngressDomain,
+    const stateWithIngressDomain = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setIngressDomain,
       payload: 'apps-crc.testing',
     });
-    const stateWithPEM = artemisCrReducer(stateWithIngressDomain, {
-      operation: ArtemisReducerOperations.activatePEMGenerationForAcceptor,
+    const stateWithPEM = reducer712(stateWithIngressDomain, {
+      operation: ArtemisReducerOperations712.activatePEMGenerationForAcceptor,
       payload: {
         acceptor: 'acceptors0',
         issuer: 'someIssuer',
@@ -821,8 +811,8 @@ describe('test the creation broker reducer', () => {
         'apps-crc.testing',
     );
     // update broker name
-    const updatedBrokerName = artemisCrReducer(stateWithPEM, {
-      operation: ArtemisReducerOperations.setBrokerName,
+    const updatedBrokerName = reducer712(stateWithPEM, {
+      operation: ArtemisReducerOperations712.setBrokerName,
       payload: 'bro',
     });
     expect(updatedBrokerName.cr.spec.acceptors[0].sslSecret).toBe(
@@ -848,8 +838,8 @@ describe('test the creation broker reducer', () => {
         'apps-crc.testing',
     );
     // update broker name
-    const updatedNamespace = artemisCrReducer(updatedBrokerName, {
-      operation: ArtemisReducerOperations.setNamespace,
+    const updatedNamespace = reducer712(updatedBrokerName, {
+      operation: ArtemisReducerOperations712.setNamespace,
       payload: 'space',
     });
     expect(updatedNamespace.cr.spec.resourceTemplates).toHaveLength(1);
@@ -866,8 +856,8 @@ describe('test the creation broker reducer', () => {
         'apps-crc.testing',
     );
     // update broker name
-    const updatedDomain = artemisCrReducer(updatedNamespace, {
-      operation: ArtemisReducerOperations.setIngressDomain,
+    const updatedDomain = reducer712(updatedNamespace, {
+      operation: ArtemisReducerOperations712.setIngressDomain,
       payload: 'tttt.com',
     });
     expect(updatedDomain.cr.spec.resourceTemplates).toHaveLength(1);
@@ -877,8 +867,8 @@ describe('test the creation broker reducer', () => {
       'ing.' + 'acceptors0' + '.' + 'bro' + '-0.' + 'space' + '.' + 'tttt.com',
     );
     // update Acceptor name
-    const updatedAcceptorName = artemisCrReducer(updatedDomain, {
-      operation: ArtemisReducerOperations.setAcceptorName,
+    const updatedAcceptorName = reducer712(updatedDomain, {
+      operation: ArtemisReducerOperations712.setAcceptorName,
       payload: {
         oldName: 'acceptors0',
         newName: 'bob',
@@ -908,16 +898,16 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test changing number of replicas while in the PEM preset gives the correct number of hosts', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateWithIngressDomain = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setIngressDomain,
+    const stateWithIngressDomain = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setIngressDomain,
       payload: 'apps-crc.testing',
     });
-    const stateWithPEM = artemisCrReducer(stateWithIngressDomain, {
-      operation: ArtemisReducerOperations.activatePEMGenerationForAcceptor,
+    const stateWithPEM = reducer712(stateWithIngressDomain, {
+      operation: ArtemisReducerOperations712.activatePEMGenerationForAcceptor,
       payload: {
         acceptor: 'acceptors0',
         issuer: 'someIssuer',
@@ -952,8 +942,8 @@ describe('test the creation broker reducer', () => {
         '.' +
         'apps-crc.testing',
     );
-    const stateWith2Replicas = artemisCrReducer(stateWithPEM, {
-      operation: ArtemisReducerOperations.incrementReplicas,
+    const stateWith2Replicas = reducer712(stateWithPEM, {
+      operation: ArtemisReducerOperations712.incrementReplicas,
     });
     expect(
       stateWith2Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0]
@@ -986,8 +976,8 @@ describe('test the creation broker reducer', () => {
     ).toHaveLength(2);
 
     const newNumber = 10;
-    const stateWith10Replicas = artemisCrReducer(stateWith2Replicas, {
-      operation: ArtemisReducerOperations.setReplicasNumber,
+    const stateWith10Replicas = reducer712(stateWith2Replicas, {
+      operation: ArtemisReducerOperations712.setReplicasNumber,
       payload: newNumber,
     });
     expect(
@@ -1010,8 +1000,8 @@ describe('test the creation broker reducer', () => {
           'apps-crc.testing',
       );
     }
-    const stateWith9Replicas = artemisCrReducer(stateWith10Replicas, {
-      operation: ArtemisReducerOperations.decrementReplicas,
+    const stateWith9Replicas = reducer712(stateWith10Replicas, {
+      operation: ArtemisReducerOperations712.decrementReplicas,
     });
     expect(
       stateWith9Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts,
@@ -1036,19 +1026,19 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test deletePEMGenerationForAcceptor', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateWithPEM = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.activatePEMGenerationForAcceptor,
+    const stateWithPEM = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.activatePEMGenerationForAcceptor,
       payload: {
         acceptor: 'acceptors0',
         issuer: 'someIssuer',
       },
     });
-    const stateWithDeletedPEM = artemisCrReducer(stateWithPEM, {
-      operation: ArtemisReducerOperations.deletePEMGenerationForAcceptor,
+    const stateWithDeletedPEM = reducer712(stateWithPEM, {
+      operation: ArtemisReducerOperations712.deletePEMGenerationForAcceptor,
       payload: 'acceptors0',
     });
     expect(stateWithDeletedPEM.cr.spec.acceptors[0].sslEnabled).toBe(undefined);
@@ -1057,12 +1047,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setAcceptorExposeMode,', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateExposeModeIngress = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorExposeMode,
+    const stateExposeModeIngress = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorExposeMode,
       payload: {
         name: 'acceptors0',
         exposeMode: ExposeMode.ingress,
@@ -1074,12 +1064,12 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setAcceptorIngressHost,', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateExposeModeIngress = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setAcceptorIngressHost,
+    const stateExposeModeIngress = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setAcceptorIngressHost,
       payload: {
         name: 'acceptors0',
         ingressHost: 'tuytutu',
@@ -1091,53 +1081,17 @@ describe('test the creation broker reducer', () => {
   });
 
   it('test setIsAcceptorExposed,', () => {
-    const initialState = newArtemisCRState('namespace');
-    const stateWith1Acceptor = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.addAcceptor,
+    const initialState = newBroker712CR('namespace');
+    const stateWith1Acceptor = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.addAcceptor,
     });
-    const stateExposeModeIngress = artemisCrReducer(stateWith1Acceptor, {
-      operation: ArtemisReducerOperations.setIsAcceptorExposed,
+    const stateExposeModeIngress = reducer712(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations712.setIsAcceptorExposed,
       payload: {
         name: 'acceptors0',
         isExposed: true,
       },
     });
     expect(stateExposeModeIngress.cr.spec.acceptors[0].expose).toBe(true);
-  });
-  it('test setYamlHasUnsavedChanges,', () => {
-    const initialState = newArtemisCRState('namespace');
-    const updatedState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setYamlHasUnsavedChanges,
-    });
-    expect(updatedState.yamlHasUnsavedChanges).toBe(true);
-    expect(updatedState.hasChanges).toBe(false);
-  });
-  it('test machine controlled model update resets the changed flags,', () => {
-    const initialState = newArtemisCRState('namespace');
-    const updatedState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setModel,
-      payload: {
-        model: initialState.cr,
-        isSetByUser: false,
-      },
-    });
-    expect(updatedState.yamlHasUnsavedChanges).toBe(false);
-    expect(updatedState.hasChanges).toBe(false);
-  });
-  it('test user controlled model update updates the flags correctly', () => {
-    const initialState = newArtemisCRState('namespace');
-    let updatedState = artemisCrReducer(initialState, {
-      operation: ArtemisReducerOperations.setYamlHasUnsavedChanges,
-    });
-    expect(updatedState.hasChanges).toBe(false);
-    updatedState = artemisCrReducer(updatedState, {
-      operation: ArtemisReducerOperations.setModel,
-      payload: {
-        model: initialState.cr,
-        isSetByUser: true,
-      },
-    });
-    expect(updatedState.yamlHasUnsavedChanges).toBe(false);
-    expect(updatedState.hasChanges).toBe(true);
   });
 });

--- a/src/reducers/7.12/reducer.ts
+++ b/src/reducers/7.12/reducer.ts
@@ -1,55 +1,15 @@
-import { AddBrokerResourceValues as FormState } from './import-types';
+import { FormState712 as FormState712 } from './import-types';
 import { BrokerCR, Acceptor, ResourceTemplate } from '@app/k8s/types';
-import { createContext } from 'react';
 import { SelectOptionObject } from '@patternfly/react-core/deprecated';
 import { ConfigType } from '@app/shared-components/FormView/BrokerProperties/ConfigurationPage/ConfigurationPage';
-
-export enum EditorType {
-  BROKER = 'broker',
-  YAML = 'yaml',
-}
+import { EditorType } from '../reducer';
 
 export enum ExposeMode {
   route = 'route',
   ingress = 'ingress',
 }
 
-export const BrokerCreationFormState = createContext<FormState>({});
-export const BrokerCreationFormDispatch =
-  createContext<React.Dispatch<ArtemisReducerActions>>(null);
-
-const artemisCRStateMap = new Map<string, FormState>();
-
-const initialCr = (namespace: string, name: string): BrokerCR => {
-  return {
-    apiVersion: 'broker.amq.io/v1beta1',
-    kind: 'ActiveMQArtemis',
-    metadata: {
-      name: name,
-      namespace: namespace,
-    },
-    spec: {},
-  };
-};
-
-export const getArtemisCRState = (name: string, ns: string): FormState => {
-  const key = name + ns;
-  let formState = artemisCRStateMap.get(key);
-  if (!formState) {
-    formState = {
-      yamlHasUnsavedChanges: false,
-      hasChanges: false,
-    };
-    formState.shouldShowYAMLMessage = true;
-    formState.editorType = EditorType.BROKER;
-    artemisCRStateMap.set(key, formState);
-  }
-  formState.cr = initialCr(ns, name);
-
-  return formState;
-};
-
-export const newArtemisCRState = (namespace: string): FormState => {
+export const newBroker712CR = (namespace: string): FormState712 => {
   const initialCr: BrokerCR = {
     apiVersion: 'broker.amq.io/v1beta1',
     kind: 'ActiveMQArtemis',
@@ -73,38 +33,24 @@ export const newArtemisCRState = (namespace: string): FormState => {
   };
 
   return {
-    shouldShowYAMLMessage: true,
     editorType: EditorType.BROKER,
     cr: initialCr,
     hasChanges: false,
     yamlHasUnsavedChanges: false,
+    brokerVersion: '7.12',
   };
-};
-
-export const convertYamlToForm = (yamlBroker: BrokerCR) => {
-  const { metadata } = yamlBroker;
-
-  const newFormData = {
-    ...yamlBroker,
-    metadata: {
-      ...metadata,
-      name: metadata.name,
-    },
-    spec: yamlBroker.spec,
-  };
-
-  return newFormData;
 };
 
 // Reducer
 
-export enum ArtemisReducerOperations {
+// Operations for 7.12 start at number 1000
+export enum ArtemisReducerOperations712 {
   /**
    * Adds an issuer as an annotation to make the cert-manager operator generate
    * the PEM certificates at runtime. Will trigger cascading effects on the CR.
    * to unset call deleteCertManagerAnnotationIssuer
    */
-  activatePEMGenerationForAcceptor,
+  activatePEMGenerationForAcceptor = 1000,
   /** adds a new acceptor to the cr */
   addAcceptor,
   /** adds a or connector to the cr */
@@ -168,8 +114,6 @@ export enum ArtemisReducerOperations {
   setConsoleSSLEnabled,
   /** Renames an acceptor or a connector */
   setConsoleSecret,
-  /** set the editor to use in the UX*/
-  setEditorType,
   /**
    * set the ingress domain (used for cert manager annotations) usually the
    * domain name of the cluster
@@ -177,17 +121,10 @@ export enum ArtemisReducerOperations {
   setIngressDomain,
   /** Is this acceptor exposed */
   setIsAcceptorExposed,
-  /** updates the whole model */
-  setModel,
   /** update the namespace of the CR */
   setNamespace,
   /** update the total number of replicas */
   setReplicasNumber,
-  /**
-   * Tells that the yaml editor has unsaved changes, when the setModel is
-   * invoked, the flag is reset to false.
-   */
-  setYamlHasUnsavedChanges,
   /** Updates the configuration's factory Class */
   updateAcceptorFactoryClass,
   /** Update the issuer of an annotation */
@@ -196,12 +133,12 @@ export enum ArtemisReducerOperations {
   updateConnectorFactoryClass,
 }
 
-type ArtemisReducerActionBase = {
+export type ArtemisReducerActionBase = {
   /** which transformation to apply onto the state */
-  operation: ArtemisReducerOperations;
+  operation: ArtemisReducerOperations712;
 };
 
-type ArtemisReducerActions =
+export type ArtemisReducerActions712 =
   | ActivatePEMGenerationForAcceptorAction
   | AddAcceptorAction
   | AddConnectorAction
@@ -233,22 +170,16 @@ type ArtemisReducerActions =
   | SetConsoleExposeModeAction
   | SetConsoleSSLEnabled
   | SetConsoleSecretAction
-  | SetEditorTypeAction
   | SetIngressDomainAction
   | SetIsAcceptorExposedAction
-  | SetModelAction
   | SetNamespaceAction
   | SetReplicasNumberAction
-  | SetYamlHasUnsavedChanges
   | UpdateAcceptorFactoryClassAction
   | UpdateAnnotationIssuerAction
   | UpdateConnectorFactoryClassAction;
 
-interface SetYamlHasUnsavedChanges extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setYamlHasUnsavedChanges;
-}
 interface UpdateAnnotationIssuerAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.updateAnnotationIssuer;
+  operation: ArtemisReducerOperations712.updateAnnotationIssuer;
   payload: {
     /** the acceptor name is needed to recover the corresponding annotation */
     acceptorName: string;
@@ -258,7 +189,7 @@ interface UpdateAnnotationIssuerAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorIngressHostAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorIngressHost;
+  operation: ArtemisReducerOperations712.setAcceptorIngressHost;
   payload: {
     /** the acceptor name */
     name: string;
@@ -268,7 +199,7 @@ interface SetAcceptorIngressHostAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorExposeModeAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorExposeMode;
+  operation: ArtemisReducerOperations712.setAcceptorExposeMode;
   payload: {
     /** the acceptor name */
     name: string;
@@ -278,7 +209,7 @@ interface SetAcceptorExposeModeAction extends ArtemisReducerActionBase {
 }
 
 interface SetIsAcceptorExposedAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setIsAcceptorExposed;
+  operation: ArtemisReducerOperations712.setIsAcceptorExposed;
   payload: {
     /** the acceptor name */
     name: string;
@@ -289,7 +220,7 @@ interface SetIsAcceptorExposedAction extends ArtemisReducerActionBase {
 
 interface ActivatePEMGenerationForAcceptorAction
   extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.activatePEMGenerationForAcceptor;
+  operation: ArtemisReducerOperations712.activatePEMGenerationForAcceptor;
   payload: {
     /** the name of the acceptor */
     acceptor: string;
@@ -300,47 +231,47 @@ interface ActivatePEMGenerationForAcceptorAction
 
 interface DeletePEMGenerationForAcceptorAction
   extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.deletePEMGenerationForAcceptor;
+  operation: ArtemisReducerOperations712.deletePEMGenerationForAcceptor;
   /** the acceptor name */
   payload: string;
 }
 
 interface AddAcceptorAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.addAcceptor;
+  operation: ArtemisReducerOperations712.addAcceptor;
 }
 
 interface AddConnectorAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.addConnector;
+  operation: ArtemisReducerOperations712.addConnector;
 }
 
 interface DecrementReplicasAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.decrementReplicas;
+  operation: ArtemisReducerOperations712.decrementReplicas;
 }
 
 interface DeleteAcceptorAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.deleteAcceptor;
+  operation: ArtemisReducerOperations712.deleteAcceptor;
   /** the name of the acceptor */
   payload: string;
 }
 
 interface DeleteConnectorAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.deleteConnector;
+  operation: ArtemisReducerOperations712.deleteConnector;
   /** the name of the acceptor */
   payload: string;
 }
 
 interface IncrementReplicasAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.incrementReplicas;
+  operation: ArtemisReducerOperations712.incrementReplicas;
 }
 
 interface SetBrokerNameAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setBrokerName;
+  operation: ArtemisReducerOperations712.setBrokerName;
   /** the name of the broker */
   payload: string;
 }
 
 interface SetConsoleCredentialsAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConsoleCredentials;
+  operation: ArtemisReducerOperations712.setConsoleCredentials;
   /** the new credentials */
   payload: {
     /** the username to login to the console */
@@ -351,32 +282,26 @@ interface SetConsoleCredentialsAction extends ArtemisReducerActionBase {
 }
 
 interface SetConsoleExposeAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConsoleExpose;
+  operation: ArtemisReducerOperations712.setConsoleExpose;
   /** is the console exposed */
   payload: boolean;
 }
 
 interface SetConsoleExposeModeAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConsoleExposeMode;
+  operation: ArtemisReducerOperations712.setConsoleExposeMode;
   /** how is the console exposed */
   payload: ExposeMode;
 }
 
 interface SetConsoleSSLEnabled extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConsoleSSLEnabled;
+  operation: ArtemisReducerOperations712.setConsoleSSLEnabled;
   /** is ssl enabled for the console */
   payload: boolean;
 }
 
-interface SetEditorTypeAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setEditorType;
-  /* What editor the user wants to use */
-  payload: EditorType;
-}
-
 interface SetAcceptorBindToAllInterfacesAction
   extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorBindToAllInterfaces;
+  operation: ArtemisReducerOperations712.setAcceptorBindToAllInterfaces;
   payload: {
     /** name of the element to update */
     name: string;
@@ -387,7 +312,7 @@ interface SetAcceptorBindToAllInterfacesAction
 
 interface SetConnectorBindToAllInterfacesAction
   extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorBindToAllInterfaces;
+  operation: ArtemisReducerOperations712.setConnectorBindToAllInterfaces;
   payload: {
     /** name of the element to update */
     name: string;
@@ -397,7 +322,7 @@ interface SetConnectorBindToAllInterfacesAction
 }
 
 interface UpdateAcceptorFactoryClassAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.updateAcceptorFactoryClass;
+  operation: ArtemisReducerOperations712.updateAcceptorFactoryClass;
   payload: {
     /** the name of the element */
     name: string;
@@ -407,7 +332,7 @@ interface UpdateAcceptorFactoryClassAction extends ArtemisReducerActionBase {
 }
 
 interface UpdateConnectorFactoryClassAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.updateConnectorFactoryClass;
+  operation: ArtemisReducerOperations712.updateConnectorFactoryClass;
   payload: {
     /** the name of the element */
     name: string;
@@ -416,18 +341,8 @@ interface UpdateConnectorFactoryClassAction extends ArtemisReducerActionBase {
   };
 }
 
-interface SetModelAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setModel;
-  payload: {
-    model: BrokerCR;
-    /** setting this to true means that form state will get considered as
-     * modified, setting to false reset that status.*/
-    isSetByUser?: boolean;
-  };
-}
-
 interface SetConnectorHostAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorHost;
+  operation: ArtemisReducerOperations712.setConnectorHost;
   payload: {
     /** the name of the configuration */
     connectorName: string;
@@ -437,7 +352,7 @@ interface SetConnectorHostAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorNameAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorName;
+  operation: ArtemisReducerOperations712.setAcceptorName;
   payload: {
     /** the name of the element */
     oldName: string;
@@ -447,7 +362,7 @@ interface SetAcceptorNameAction extends ArtemisReducerActionBase {
 }
 
 interface SetConnectorNameAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorName;
+  operation: ArtemisReducerOperations712.setConnectorName;
   payload: {
     /** the name of the element */
     oldName: string;
@@ -457,7 +372,7 @@ interface SetConnectorNameAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorOtherParamsAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorOtherParams;
+  operation: ArtemisReducerOperations712.setAcceptorOtherParams;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -467,7 +382,7 @@ interface SetAcceptorOtherParamsAction extends ArtemisReducerActionBase {
 }
 
 interface SetConnectorOtherParamsAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorOtherParams;
+  operation: ArtemisReducerOperations712.setConnectorOtherParams;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -477,7 +392,7 @@ interface SetConnectorOtherParamsAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorPortAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorPort;
+  operation: ArtemisReducerOperations712.setAcceptorPort;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -487,7 +402,7 @@ interface SetAcceptorPortAction extends ArtemisReducerActionBase {
 }
 
 interface SetConnectorPortAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorPort;
+  operation: ArtemisReducerOperations712.setConnectorPort;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -497,7 +412,7 @@ interface SetConnectorPortAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorProtocolsAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorProtocols;
+  operation: ArtemisReducerOperations712.setAcceptorProtocols;
   payload: {
     /** the name of the configuration */
     configName: string;
@@ -507,7 +422,7 @@ interface SetAcceptorProtocolsAction extends ArtemisReducerActionBase {
 }
 
 interface SetConnectorProtocolsAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorProtocols;
+  operation: ArtemisReducerOperations712.setConnectorProtocols;
   payload: {
     /** the name of the configuration */
     configName: string;
@@ -517,7 +432,7 @@ interface SetConnectorProtocolsAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorSSLEnabledAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorSSLEnabled;
+  operation: ArtemisReducerOperations712.setAcceptorSSLEnabled;
   payload: {
     /** the name of the element */
     name: string;
@@ -527,7 +442,7 @@ interface SetAcceptorSSLEnabledAction extends ArtemisReducerActionBase {
 }
 
 interface SetConnectorSSLEnabledAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorSSLEnabled;
+  operation: ArtemisReducerOperations712.setConnectorSSLEnabled;
   payload: {
     /** the name of the element */
     name: string;
@@ -537,7 +452,7 @@ interface SetConnectorSSLEnabledAction extends ArtemisReducerActionBase {
 }
 
 interface SetAcceptorSecretAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setAcceptorSecret;
+  operation: ArtemisReducerOperations712.setAcceptorSecret;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -549,7 +464,7 @@ interface SetAcceptorSecretAction extends ArtemisReducerActionBase {
 }
 
 interface SetConnectorSecretAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConnectorSecret;
+  operation: ArtemisReducerOperations712.setConnectorSecret;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -561,7 +476,7 @@ interface SetConnectorSecretAction extends ArtemisReducerActionBase {
 }
 
 interface SetConsoleSecretAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setConsoleSecret;
+  operation: ArtemisReducerOperations712.setConsoleSecret;
   payload: {
     /** the name of the configuration */
     name: string;
@@ -573,19 +488,19 @@ interface SetConsoleSecretAction extends ArtemisReducerActionBase {
 }
 
 interface SetNamespaceAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setNamespace;
+  operation: ArtemisReducerOperations712.setNamespace;
   /** the new namespace for the CR */
   payload: string;
 }
 
 interface SetReplicasNumberAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setReplicasNumber;
+  operation: ArtemisReducerOperations712.setReplicasNumber;
   /** the total number of replicas */
   payload: number;
 }
 
 interface SetIngressDomainAction extends ArtemisReducerActionBase {
-  operation: ArtemisReducerOperations.setIngressDomain;
+  operation: ArtemisReducerOperations712.setIngressDomain;
   /** the domain of the cluster. Only passing the string is equivalent as saying
    * that the value is set by the user. Otherwise this value can be customized.
    * Setting isSetByUser to false has for effect to state that the form doesn't
@@ -597,6 +512,7 @@ interface SetIngressDomainAction extends ArtemisReducerActionBase {
         isSetByUser?: boolean;
       };
 }
+
 /**
  *
  * The core of the reducer functionality. Switch case on the Action and apply
@@ -604,35 +520,25 @@ interface SetIngressDomainAction extends ArtemisReducerActionBase {
  * the modifications are applied
  *
  */
-export const artemisCrReducer: React.Reducer<
-  FormState,
-  ArtemisReducerActions
+export const reducer712: React.Reducer<
+  FormState712,
+  ArtemisReducerActions712
 > = (prevFormState, action) => {
   const formState = { ...prevFormState };
-  if (
-    action.operation !== ArtemisReducerOperations.setEditorType &&
-    action.operation !== ArtemisReducerOperations.setYamlHasUnsavedChanges
-  ) {
-    formState.hasChanges = true;
-  }
-
   // set the individual fields
   switch (action.operation) {
-    case ArtemisReducerOperations.setYamlHasUnsavedChanges:
-      formState.yamlHasUnsavedChanges = true;
-      break;
-    case ArtemisReducerOperations.updateAnnotationIssuer:
+    case ArtemisReducerOperations712.updateAnnotationIssuer:
       updateAnnotationIssuer(
         formState.cr,
         action.payload.acceptorName,
         action.payload.newIssuer,
       );
       break;
-    case ArtemisReducerOperations.setAcceptorIngressHost:
+    case ArtemisReducerOperations712.setAcceptorIngressHost:
       getAcceptor(formState.cr, action.payload.name).ingressHost =
         action.payload.ingressHost;
       break;
-    case ArtemisReducerOperations.setAcceptorExposeMode:
+    case ArtemisReducerOperations712.setAcceptorExposeMode:
       if (action.payload) {
         getAcceptor(formState.cr, action.payload.name).exposeMode =
           action.payload.exposeMode;
@@ -640,38 +546,32 @@ export const artemisCrReducer: React.Reducer<
         delete getAcceptor(formState.cr, action.payload.name).exposeMode;
       }
       break;
-    case ArtemisReducerOperations.setIsAcceptorExposed:
+    case ArtemisReducerOperations712.setIsAcceptorExposed:
       getAcceptor(formState.cr, action.payload.name).expose =
         action.payload.isExposed;
       break;
-    case ArtemisReducerOperations.setEditorType:
-      formState.editorType = action.payload;
-      if (formState.editorType === EditorType.BROKER) {
-        formState.yamlHasUnsavedChanges = false;
-      }
-      break;
-    case ArtemisReducerOperations.setNamespace:
+    case ArtemisReducerOperations712.setNamespace:
       updateNamespace(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations.setReplicasNumber:
+    case ArtemisReducerOperations712.setReplicasNumber:
       updateDeploymentSize(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations.incrementReplicas:
+    case ArtemisReducerOperations712.incrementReplicas:
       updateDeploymentSize(
         formState.cr,
         formState.cr.spec.deploymentPlan.size + 1,
       );
       break;
-    case ArtemisReducerOperations.decrementReplicas:
+    case ArtemisReducerOperations712.decrementReplicas:
       updateDeploymentSize(
         formState.cr,
         formState.cr.spec.deploymentPlan.size - 1,
       );
       break;
-    case ArtemisReducerOperations.setBrokerName:
+    case ArtemisReducerOperations712.setBrokerName:
       updateBrokerName(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations.activatePEMGenerationForAcceptor:
+    case ArtemisReducerOperations712.activatePEMGenerationForAcceptor:
       activatePEMGenerationForAcceptor(formState.cr, action.payload.acceptor);
       setIssuerForAcceptor(
         formState.cr,
@@ -679,24 +579,24 @@ export const artemisCrReducer: React.Reducer<
         action.payload.issuer,
       );
       break;
-    case ArtemisReducerOperations.deletePEMGenerationForAcceptor:
+    case ArtemisReducerOperations712.deletePEMGenerationForAcceptor:
       clearAcceptorCertManagerConfig(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations.addAcceptor:
+    case ArtemisReducerOperations712.addAcceptor:
       addConfig(formState.cr, ConfigType.acceptors);
       break;
-    case ArtemisReducerOperations.addConnector:
+    case ArtemisReducerOperations712.addConnector:
       addConfig(formState.cr, ConfigType.connectors);
       break;
-    case ArtemisReducerOperations.deleteAcceptor:
+    case ArtemisReducerOperations712.deleteAcceptor:
       // before deleting an acceptor, remove any linked annotations
       deleteCertManagerAnnotation(formState.cr, action.payload);
       deleteConfig(formState.cr, ConfigType.acceptors, action.payload);
       break;
-    case ArtemisReducerOperations.deleteConnector:
+    case ArtemisReducerOperations712.deleteConnector:
       deleteConfig(formState.cr, ConfigType.connectors, action.payload);
       break;
-    case ArtemisReducerOperations.setAcceptorName:
+    case ArtemisReducerOperations712.setAcceptorName:
       renameConfig(
         formState.cr,
         ConfigType.acceptors,
@@ -711,7 +611,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.newName,
       );
       break;
-    case ArtemisReducerOperations.setConnectorName:
+    case ArtemisReducerOperations712.setConnectorName:
       renameConfig(
         formState.cr,
         ConfigType.connectors,
@@ -719,7 +619,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.newName,
       );
       break;
-    case ArtemisReducerOperations.setAcceptorSecret:
+    case ArtemisReducerOperations712.setAcceptorSecret:
       // when the user sets the acceptor secret manually, remove any linked
       // annotations
       clearAcceptorCertManagerConfig(formState.cr, action.payload.name);
@@ -740,7 +640,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.isCa,
       );
       break;
-    case ArtemisReducerOperations.setConnectorSecret:
+    case ArtemisReducerOperations712.setConnectorSecret:
       updateConfigSecret(
         formState.cr,
         ConfigType.connectors,
@@ -749,7 +649,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.isCa,
       );
       break;
-    case ArtemisReducerOperations.setConsoleSecret:
+    case ArtemisReducerOperations712.setConsoleSecret:
       updateConfigSecret(
         formState.cr,
         ConfigType.console,
@@ -758,23 +658,23 @@ export const artemisCrReducer: React.Reducer<
         action.payload.isCa,
       );
       break;
-    case ArtemisReducerOperations.setConsoleSSLEnabled:
+    case ArtemisReducerOperations712.setConsoleSSLEnabled:
       formState.cr.spec.console.sslEnabled = action.payload;
       if (!action.payload) {
         delete formState.cr.spec.console.useClientAuth;
       }
       break;
-    case ArtemisReducerOperations.setConsoleExposeMode:
+    case ArtemisReducerOperations712.setConsoleExposeMode:
       formState.cr.spec.console.exposeMode = action.payload;
       break;
-    case ArtemisReducerOperations.setConsoleExpose:
+    case ArtemisReducerOperations712.setConsoleExpose:
       formState.cr.spec.console.expose = action.payload;
       break;
-    case ArtemisReducerOperations.setConsoleCredentials:
+    case ArtemisReducerOperations712.setConsoleCredentials:
       formState.cr.spec.console.adminUser = action.payload.adminUser;
       formState.cr.spec.console.adminPassword = action.payload.adminPassword;
       break;
-    case ArtemisReducerOperations.setAcceptorPort:
+    case ArtemisReducerOperations712.setAcceptorPort:
       updateConfigPort(
         formState.cr,
         ConfigType.acceptors,
@@ -782,7 +682,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.port,
       );
       break;
-    case ArtemisReducerOperations.setConnectorPort:
+    case ArtemisReducerOperations712.setConnectorPort:
       updateConfigPort(
         formState.cr,
         ConfigType.connectors,
@@ -790,14 +690,14 @@ export const artemisCrReducer: React.Reducer<
         action.payload.port,
       );
       break;
-    case ArtemisReducerOperations.setConnectorHost:
+    case ArtemisReducerOperations712.setConnectorHost:
       updateConnectorHost(
         formState.cr,
         action.payload.connectorName,
         action.payload.host,
       );
       break;
-    case ArtemisReducerOperations.setAcceptorBindToAllInterfaces:
+    case ArtemisReducerOperations712.setAcceptorBindToAllInterfaces:
       updateConfigBindToAllInterfaces(
         formState.cr,
         ConfigType.acceptors,
@@ -805,7 +705,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.bindToAllInterfaces,
       );
       break;
-    case ArtemisReducerOperations.setConnectorBindToAllInterfaces:
+    case ArtemisReducerOperations712.setConnectorBindToAllInterfaces:
       updateConfigBindToAllInterfaces(
         formState.cr,
         ConfigType.connectors,
@@ -813,7 +713,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.bindToAllInterfaces,
       );
       break;
-    case ArtemisReducerOperations.setAcceptorProtocols:
+    case ArtemisReducerOperations712.setAcceptorProtocols:
       updateConfigProtocols(
         formState.cr,
         ConfigType.acceptors,
@@ -821,7 +721,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.protocols,
       );
       break;
-    case ArtemisReducerOperations.setConnectorProtocols:
+    case ArtemisReducerOperations712.setConnectorProtocols:
       updateConfigProtocols(
         formState.cr,
         ConfigType.connectors,
@@ -829,7 +729,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.protocols,
       );
       break;
-    case ArtemisReducerOperations.setAcceptorOtherParams:
+    case ArtemisReducerOperations712.setAcceptorOtherParams:
       updateConfigOtherParams(
         formState.cr,
         ConfigType.acceptors,
@@ -837,7 +737,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.otherParams,
       );
       break;
-    case ArtemisReducerOperations.setConnectorOtherParams:
+    case ArtemisReducerOperations712.setConnectorOtherParams:
       updateConfigOtherParams(
         formState.cr,
         ConfigType.connectors,
@@ -845,7 +745,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.otherParams,
       );
       break;
-    case ArtemisReducerOperations.setAcceptorSSLEnabled:
+    case ArtemisReducerOperations712.setAcceptorSSLEnabled:
       updateConfigSSLEnabled(
         formState.cr,
         ConfigType.acceptors,
@@ -853,7 +753,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.sslEnabled,
       );
       break;
-    case ArtemisReducerOperations.setConnectorSSLEnabled:
+    case ArtemisReducerOperations712.setConnectorSSLEnabled:
       updateConfigSSLEnabled(
         formState.cr,
         ConfigType.connectors,
@@ -861,7 +761,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.sslEnabled,
       );
       break;
-    case ArtemisReducerOperations.updateAcceptorFactoryClass:
+    case ArtemisReducerOperations712.updateAcceptorFactoryClass:
       updateConfigFactoryClass(
         formState.cr,
         ConfigType.acceptors,
@@ -869,7 +769,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.class,
       );
       break;
-    case ArtemisReducerOperations.updateConnectorFactoryClass:
+    case ArtemisReducerOperations712.updateConnectorFactoryClass:
       updateConfigFactoryClass(
         formState.cr,
         ConfigType.connectors,
@@ -877,12 +777,7 @@ export const artemisCrReducer: React.Reducer<
         action.payload.class,
       );
       break;
-    case ArtemisReducerOperations.setModel:
-      setModel(formState, action.payload.model);
-      formState.yamlHasUnsavedChanges = false;
-      formState.hasChanges = action.payload.isSetByUser;
-      break;
-    case ArtemisReducerOperations.setIngressDomain:
+    case ArtemisReducerOperations712.setIngressDomain:
       if (typeof action.payload === 'string') {
         updateIngressDomain(formState.cr, action.payload);
       } else {
@@ -1674,10 +1569,6 @@ const updateConfigFactoryClass = (
       }
     }
   }
-};
-
-const setModel = (formState: FormState, model: BrokerCR): void => {
-  formState.cr = model;
 };
 
 // Getters

--- a/src/reducers/7.13/import-types.ts
+++ b/src/reducers/7.13/import-types.ts
@@ -1,0 +1,3 @@
+import { FormState712 } from '../7.12/import-types';
+
+export type FormState713 = FormState712;

--- a/src/reducers/7.13/reducer.ts
+++ b/src/reducers/7.13/reducer.ts
@@ -1,0 +1,30 @@
+import { reducer712, ArtemisReducerActions712 } from '../7.12/reducer';
+import { FormState713 } from './import-types';
+
+// Operations for 7.13 start at number 2000
+export enum ArtemisReducerOperations713 {}
+
+export type ReducerActionBase = {
+  operation: ArtemisReducerOperations713;
+};
+
+// 7.13 is 7.12 + extras
+export type ArtemisReducerActions713 = ArtemisReducerActions712;
+
+export const reducer713: React.Reducer<
+  FormState713,
+  ArtemisReducerActions713
+> = (prevFormState, action) => {
+  const formState = { ...prevFormState };
+
+  // set the individual fields
+  switch (action.operation) {
+    default:
+      return reducer712(
+        formState,
+        action as ArtemisReducerActions712,
+      ) as FormState713;
+  }
+
+  return formState;
+};

--- a/src/reducers/reducer.test.ts
+++ b/src/reducers/reducer.test.ts
@@ -1,0 +1,67 @@
+import {
+  ArtemisReducerGlobalOperations,
+  EditorType,
+  artemisCrReducer,
+  newArtemisCR,
+} from './reducer';
+
+describe('test the 7.13 reducer', () => {
+  it('test setBrokerVersion', () => {
+    const initialState = newArtemisCR('namespace');
+    const newState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerGlobalOperations.setBrokerVersion,
+      payload: '7.12',
+    });
+    expect(newState.brokerVersion).toBe('7.12');
+    const newState2 = artemisCrReducer(initialState, {
+      operation: ArtemisReducerGlobalOperations.setBrokerVersion,
+      payload: '7.13',
+    });
+    expect(newState2.brokerVersion).toBe('7.13');
+  });
+
+  it('test setEditorType', () => {
+    const initialState = newArtemisCR('namespace');
+    const newState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerGlobalOperations.setEditorType,
+      payload: EditorType.BROKER,
+    });
+    expect(newState.editorType).toBe(EditorType.BROKER);
+  });
+  it('test setYamlHasUnsavedChanges,', () => {
+    const initialState = newArtemisCR('namespace');
+    const updatedState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges,
+    });
+    expect(updatedState.yamlHasUnsavedChanges).toBe(true);
+    expect(updatedState.hasChanges).toBe(false);
+  });
+  it('test machine controlled model update resets the changed flags,', () => {
+    const initialState = newArtemisCR('namespace');
+    const updatedState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerGlobalOperations.setModel,
+      payload: {
+        model: initialState.cr,
+        isSetByUser: false,
+      },
+    });
+    expect(updatedState.yamlHasUnsavedChanges).toBe(false);
+    expect(updatedState.hasChanges).toBe(false);
+  });
+  it('test user controlled model update updates the flags correctly', () => {
+    const initialState = newArtemisCR('namespace');
+    let updatedState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges,
+    });
+    expect(updatedState.hasChanges).toBe(false);
+    updatedState = artemisCrReducer(updatedState, {
+      operation: ArtemisReducerGlobalOperations.setModel,
+      payload: {
+        model: initialState.cr,
+        isSetByUser: true,
+      },
+    });
+    expect(updatedState.yamlHasUnsavedChanges).toBe(false);
+    expect(updatedState.hasChanges).toBe(true);
+  });
+});

--- a/src/reducers/reducer.ts
+++ b/src/reducers/reducer.ts
@@ -1,0 +1,130 @@
+import { createContext } from 'react';
+import { newBroker712CR, reducer712 as reducer712 } from './7.12/reducer';
+import { reducer713 as reducer713 } from './7.13/reducer';
+import { FormState712 } from './7.12/import-types';
+import { FormState713 } from './7.13/import-types';
+import { ArtemisReducerActions712 } from './7.12/reducer';
+import { ArtemisReducerActions713 } from './7.13/reducer';
+import { BrokerCR } from '@app/k8s/types';
+
+export enum EditorType {
+  BROKER = 'broker',
+  YAML = 'yaml',
+}
+
+export const BrokerCreationFormState = createContext<FormState>({});
+export const BrokerCreationFormDispatch =
+  createContext<React.Dispatch<ReducerActions>>(null);
+
+export interface BaseFormState {
+  brokerVersion?: '7.12' | '7.13';
+}
+
+export type FormState = FormState712 | FormState713;
+
+// Global operation start at number 0
+export enum ArtemisReducerGlobalOperations {
+  setBrokerVersion = 0,
+  /**
+   * Tells that the yaml editor has unsaved changes, when the setModel is
+   * invoked, the flag is reset to false.
+   */
+  setYamlHasUnsavedChanges,
+  /** set the editor to use in the UX*/
+  setEditorType,
+  /** updates the whole model */
+  setModel,
+}
+
+export type ArtemisReducerActionBase = {
+  operation: ArtemisReducerGlobalOperations;
+};
+
+interface SetBrokerVersionAction extends ArtemisReducerActionBase {
+  operation: ArtemisReducerGlobalOperations.setBrokerVersion;
+  payload: '7.12' | '7.13';
+}
+
+interface SetEditorTypeAction extends ArtemisReducerActionBase {
+  operation: ArtemisReducerGlobalOperations.setEditorType;
+  /* What editor the user wants to use */
+  payload: EditorType;
+}
+
+interface SetYamlHasUnsavedChanges extends ArtemisReducerActionBase {
+  operation: ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges;
+}
+
+interface SetModelAction extends ArtemisReducerActionBase {
+  operation: ArtemisReducerGlobalOperations.setModel;
+  payload: {
+    model: BrokerCR;
+    /** setting this to true means that form state will get considered as
+     * modified, setting to false reset that status.*/
+    isSetByUser?: boolean;
+  };
+}
+
+export const newArtemisCR = (namespace: string): FormState => {
+  const state = newBroker712CR(namespace);
+  state.brokerVersion = '7.13';
+  return state;
+};
+
+// 7.13 is 7.12 + extras
+export type ReducerActions =
+  | ArtemisReducerActions712
+  | ArtemisReducerActions713
+  | SetEditorTypeAction
+  | SetYamlHasUnsavedChanges
+  | SetModelAction
+  | SetBrokerVersionAction;
+
+export const artemisCrReducer: React.Reducer<FormState, ReducerActions> = (
+  prevFormState,
+  action,
+) => {
+  const formState = { ...prevFormState };
+  if (
+    action.operation !== ArtemisReducerGlobalOperations.setEditorType &&
+    action.operation !== ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges
+  ) {
+    formState.hasChanges = true;
+  }
+  switch (action.operation) {
+    case ArtemisReducerGlobalOperations.setBrokerVersion:
+      formState.brokerVersion = action.payload;
+      return formState;
+    case ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges:
+      formState.yamlHasUnsavedChanges = true;
+      return formState;
+    case ArtemisReducerGlobalOperations.setEditorType:
+      formState.editorType = action.payload;
+      if (formState.editorType === EditorType.BROKER) {
+        formState.yamlHasUnsavedChanges = false;
+      }
+      return formState;
+    case ArtemisReducerGlobalOperations.setModel:
+      formState.cr = action.payload.model;
+      formState.yamlHasUnsavedChanges = false;
+      formState.hasChanges = action.payload.isSetByUser;
+      return formState;
+  }
+  switch (formState.brokerVersion) {
+    case '7.13':
+      return reducer713(
+        formState as FormState713,
+        action as ArtemisReducerActions713,
+      );
+    default:
+    case '7.12':
+      return reducer712(
+        formState as FormState712,
+        action as ArtemisReducerActions712,
+      );
+  }
+};
+
+export const getBrokerVersion = (formState: FormState) => {
+  return formState.brokerVersion;
+};

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/AcceptorConfigPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/AcceptorConfigPage.tsx
@@ -10,9 +10,11 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   ExposeMode,
   getAcceptor,
   getConfigBindToAllInterfaces,
@@ -58,7 +60,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
   const onChangeClass = (value: string) => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.updateAcceptorFactoryClass,
+        operation: ArtemisReducerOperations712.updateAcceptorFactoryClass,
         payload: {
           name: configName,
           class: value as 'invm' | 'netty',
@@ -67,7 +69,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.updateConnectorFactoryClass,
+        operation: ArtemisReducerOperations712.updateConnectorFactoryClass,
         payload: {
           name: configName,
           class: value as 'invm' | 'netty',
@@ -78,7 +80,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
 
   const onHostChange = (host: string) => {
     dispatch({
-      operation: ArtemisReducerOperations.setConnectorHost,
+      operation: ArtemisReducerOperations712.setConnectorHost,
       payload: {
         connectorName: configName,
         host: host,
@@ -89,7 +91,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
   const onPortChange = (port: string) => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorPort,
+        operation: ArtemisReducerOperations712.setAcceptorPort,
         payload: {
           name: configName,
           port: Number(port),
@@ -98,7 +100,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorPort,
+        operation: ArtemisReducerOperations712.setConnectorPort,
         payload: {
           name: configName,
           port: Number(port),
@@ -110,7 +112,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
   const onProtocolsChange = (prot: string) => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorProtocols,
+        operation: ArtemisReducerOperations712.setAcceptorProtocols,
         payload: {
           configName: configName,
           protocols: prot,
@@ -119,7 +121,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorProtocols,
+        operation: ArtemisReducerOperations712.setConnectorProtocols,
         payload: {
           configName: configName,
           protocols: prot,
@@ -131,7 +133,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
   const handleSSLEnabled = (value: boolean) => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorSSLEnabled,
+        operation: ArtemisReducerOperations712.setAcceptorSSLEnabled,
         payload: {
           name: configName,
           sslEnabled: value,
@@ -140,7 +142,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorSSLEnabled,
+        operation: ArtemisReducerOperations712.setConnectorSSLEnabled,
         payload: {
           name: configName,
           sslEnabled: value,
@@ -152,7 +154,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
   const onBindToAllInterfacesChange = (checked: boolean) => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorBindToAllInterfaces,
+        operation: ArtemisReducerOperations712.setAcceptorBindToAllInterfaces,
         payload: {
           name: configName,
           bindToAllInterfaces: checked,
@@ -161,7 +163,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorBindToAllInterfaces,
+        operation: ArtemisReducerOperations712.setConnectorBindToAllInterfaces,
         payload: {
           name: configName,
           bindToAllInterfaces: checked,
@@ -248,7 +250,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 id={'check-expose' + configType + configName}
                 onChange={(_event, v) =>
                   dispatch({
-                    operation: ArtemisReducerOperations.setIsAcceptorExposed,
+                    operation: ArtemisReducerOperations712.setIsAcceptorExposed,
                     payload: {
                       name: configName,
                       isExposed: v,
@@ -269,7 +271,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               }
               setSelectedExposeMode={(v) =>
                 dispatch({
-                  operation: ArtemisReducerOperations.setAcceptorExposeMode,
+                  operation: ArtemisReducerOperations712.setAcceptorExposeMode,
                   payload: {
                     name: configName,
                     exposeMode: v ? (v as ExposeMode) : undefined,
@@ -278,7 +280,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               }
               clearExposeMode={() =>
                 dispatch({
-                  operation: ArtemisReducerOperations.setAcceptorExposeMode,
+                  operation: ArtemisReducerOperations712.setAcceptorExposeMode,
                   payload: {
                     name: configName,
                     exposeMode: undefined,
@@ -350,7 +352,8 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 }
                 onChange={(_event, v) =>
                   dispatch({
-                    operation: ArtemisReducerOperations.setAcceptorIngressHost,
+                    operation:
+                      ArtemisReducerOperations712.setAcceptorIngressHost,
                     payload: {
                       name: configName,
                       ingressHost: v,

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/ListPresets/ListPresets.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/ListPresets/ListPresets.tsx
@@ -7,9 +7,11 @@ import { FC, useContext } from 'react';
 import { useTranslation } from '@app/i18n/i18n';
 import { Acceptor } from '@app/k8s/types';
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   getAcceptorFromCertManagerResourceTemplate,
   getCertManagerResourceTemplateFromAcceptor,
 } from '@app/reducers/7.12/reducer';
@@ -45,7 +47,7 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
               action={() =>
                 dispatch({
                   operation:
-                    ArtemisReducerOperations.deletePEMGenerationForAcceptor,
+                    ArtemisReducerOperations712.deletePEMGenerationForAcceptor,
                   payload: acceptor.name,
                 })
               }
@@ -61,7 +63,7 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
           }
           setSelectedIssuer={(issuer: string) => {
             dispatch({
-              operation: ArtemisReducerOperations.updateAnnotationIssuer,
+              operation: ArtemisReducerOperations712.updateAnnotationIssuer,
               payload: {
                 acceptorName: acceptor.name,
                 newIssuer: issuer,
@@ -70,7 +72,7 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
           }}
           clearIssuer={() => {
             dispatch({
-              operation: ArtemisReducerOperations.updateAnnotationIssuer,
+              operation: ArtemisReducerOperations712.updateAnnotationIssuer,
               payload: {
                 acceptorName: acceptor.name,
                 newIssuer: '',

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/OtherParameters/OtherParameters.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/OtherParameters/OtherParameters.tsx
@@ -1,7 +1,9 @@
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   getConfigOtherParams,
 } from '@app/reducers/7.12/reducer';
 import { FC, useContext, useState } from 'react';
@@ -42,7 +44,7 @@ const Param: FC<ParamProps> = ({
     }
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorOtherParams,
+        operation: ArtemisReducerOperations712.setAcceptorOtherParams,
         payload: {
           name: configName,
           otherParams: params,
@@ -51,7 +53,7 @@ const Param: FC<ParamProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorOtherParams,
+        operation: ArtemisReducerOperations712.setConnectorOtherParams,
         payload: {
           name: configName,
           otherParams: params,
@@ -121,7 +123,7 @@ export const OtherParameters: FC<OtherParametersProps> = ({
     params.set(key, value);
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorOtherParams,
+        operation: ArtemisReducerOperations712.setAcceptorOtherParams,
         payload: {
           name: configName,
           otherParams: params,
@@ -130,7 +132,7 @@ export const OtherParameters: FC<OtherParametersProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorOtherParams,
+        operation: ArtemisReducerOperations712.setConnectorOtherParams,
         payload: {
           name: configName,
           otherParams: params,

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/PresetAlertPopover/PresetAlertPopover.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/PresetAlertPopover/PresetAlertPopover.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext } from 'react';
 import { ConfigType } from '../../../../ConfigurationPage';
+import { BrokerCreationFormState } from '@app/reducers/reducer';
 import {
-  BrokerCreationFormState,
   getAcceptor,
   getCertManagerResourceTemplateFromAcceptor,
 } from '@app/reducers/7.12/reducer';

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigSection.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigSection.tsx
@@ -1,9 +1,11 @@
 import { FC, useContext } from 'react';
 import { ConfigType } from '../../ConfigurationPage';
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   getAcceptor,
 } from '@app/reducers/7.12/reducer';
 import {
@@ -28,13 +30,13 @@ export const AcceptorConfigSection: FC<AcceptorConfigSectionProps> = ({
   const onDelete = () => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.deleteAcceptor,
+        operation: ArtemisReducerOperations712.deleteAcceptor,
         payload: configName,
       });
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.deleteConnector,
+        operation: ArtemisReducerOperations712.deleteConnector,
         payload: configName,
       });
     }

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/ConfigRenamingModal/ConfigRenamingModal.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/ConfigRenamingModal/ConfigRenamingModal.tsx
@@ -7,9 +7,11 @@ import {
 } from '@patternfly/react-core';
 import { FC, useContext, useState } from 'react';
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   listConfigs,
 } from '../../../../../../../reducers/7.12/reducer';
 import { useTranslation } from '../../../../../../../i18n/i18n';
@@ -33,7 +35,7 @@ export const ConfigRenamingModal: FC<ConfigRenamingModalProps> = ({
   const handleNewName = () => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorName,
+        operation: ArtemisReducerOperations712.setAcceptorName,
         payload: {
           oldName: initName,
           newName: newName,
@@ -42,7 +44,7 @@ export const ConfigRenamingModal: FC<ConfigRenamingModalProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorName,
+        operation: ArtemisReducerOperations712.setConnectorName,
         payload: {
           oldName: initName,
           newName: newName,

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
@@ -21,9 +21,11 @@ import { CSSProperties, FC, useContext, useState } from 'react';
 import { useTranslation } from '@app/i18n/i18n';
 import { Acceptor } from '@app/k8s/types';
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   getCertManagerResourceTemplateFromAcceptor,
 } from '@app/reducers/7.12/reducer';
 import { SelectIssuerDrawer } from '../SelectIssuerDrawer/SelectIssuerDrawer';
@@ -68,7 +70,7 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
       return;
     }
     dispatch({
-      operation: ArtemisReducerOperations.activatePEMGenerationForAcceptor,
+      operation: ArtemisReducerOperations712.activatePEMGenerationForAcceptor,
       payload: {
         acceptor: selectedAcceptor,
         issuer: selectedIssuer,

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/SelectIssuerDrawer/SelectIssuerDrawer.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/SelectIssuerDrawer/SelectIssuerDrawer.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@app/i18n/i18n';
-import { BrokerCreationFormState } from '@app/reducers/7.12/reducer';
+import { BrokerCreationFormState } from '@app/reducers/reducer';
 import { CertIssuerModel, CertModel } from '@app/k8s/models';
 import { IssuerResource } from '@app/k8s/types';
 import {

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorsConfigPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorsConfigPage.tsx
@@ -1,7 +1,9 @@
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   listConfigs,
 } from '@app/reducers/7.12/reducer';
 import { FC, useContext } from 'react';
@@ -37,12 +39,12 @@ export const AcceptorsConfigPage: FC<AcceptorsConfigProps> = ({ brokerId }) => {
   const addNewConfig = () => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.addAcceptor,
+        operation: ArtemisReducerOperations712.addAcceptor,
       });
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.addConnector,
+        operation: ArtemisReducerOperations712.addConnector,
       });
     }
   };

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
@@ -1,8 +1,10 @@
 import { FC, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   getAcceptor,
   getCertManagerResourceTemplateFromAcceptor,
   getConfigSecret,
@@ -173,7 +175,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
   const clearSelection = () => {
     if (configType === ConfigType.acceptors) {
       dispatch({
-        operation: ArtemisReducerOperations.setAcceptorSecret,
+        operation: ArtemisReducerOperations712.setAcceptorSecret,
         payload: {
           secret: undefined,
           name: configName,
@@ -183,7 +185,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
     }
     if (configType === ConfigType.connectors) {
       dispatch({
-        operation: ArtemisReducerOperations.setConnectorSecret,
+        operation: ArtemisReducerOperations712.setConnectorSecret,
         payload: {
           secret: undefined,
           name: configName,
@@ -193,7 +195,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
     }
     if (configType === ConfigType.console) {
       dispatch({
-        operation: ArtemisReducerOperations.setConsoleSecret,
+        operation: ArtemisReducerOperations712.setConsoleSecret,
         payload: {
           secret: undefined,
           name: configName,
@@ -214,7 +216,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
     } else {
       if (configType === ConfigType.acceptors) {
         dispatch({
-          operation: ArtemisReducerOperations.setAcceptorSecret,
+          operation: ArtemisReducerOperations712.setAcceptorSecret,
           payload: {
             secret: value,
             name: configName,
@@ -224,7 +226,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
       }
       if (configType === ConfigType.connectors) {
         dispatch({
-          operation: ArtemisReducerOperations.setConnectorSecret,
+          operation: ArtemisReducerOperations712.setConnectorSecret,
           payload: {
             secret: value,
             name: configName,
@@ -234,7 +236,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
       }
       if (configType === ConfigType.console) {
         dispatch({
-          operation: ArtemisReducerOperations.setConsoleSecret,
+          operation: ArtemisReducerOperations712.setConsoleSecret,
           payload: {
             secret: value,
             name: configName,
@@ -498,7 +500,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
           setCaGenFromTlsSecret('');
           if (configType === ConfigType.acceptors) {
             dispatch({
-              operation: ArtemisReducerOperations.setAcceptorSecret,
+              operation: ArtemisReducerOperations712.setAcceptorSecret,
               payload: {
                 secret: caSecName,
                 name: configName,
@@ -508,7 +510,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
           }
           if (configType === ConfigType.connectors) {
             dispatch({
-              operation: ArtemisReducerOperations.setConnectorSecret,
+              operation: ArtemisReducerOperations712.setConnectorSecret,
               payload: {
                 secret: caSecName,
                 name: configName,
@@ -518,7 +520,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
           }
           if (configType === ConfigType.console) {
             dispatch({
-              operation: ArtemisReducerOperations.setConsoleSecret,
+              operation: ArtemisReducerOperations712.setConsoleSecret,
               payload: {
                 secret: caSecName,
                 name: configName,

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/ConsoleConfigPage/ConsoleConfigPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/ConsoleConfigPage/ConsoleConfigPage.tsx
@@ -1,7 +1,9 @@
 import {
-  ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+} from '@app/reducers/reducer';
+import {
+  ArtemisReducerOperations712,
   ExposeMode,
 } from '@app/reducers/7.12/reducer';
 
@@ -63,21 +65,21 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
 
   const handleSSLEnabled = (value: boolean) => {
     dispatch({
-      operation: ArtemisReducerOperations.setConsoleSSLEnabled,
+      operation: ArtemisReducerOperations712.setConsoleSSLEnabled,
       payload: value,
     });
   };
 
   const setConsoleExpose = (value: boolean) => {
     dispatch({
-      operation: ArtemisReducerOperations.setConsoleExpose,
+      operation: ArtemisReducerOperations712.setConsoleExpose,
       payload: value,
     });
   };
 
   const setConsoleExposeMode = (value: ExposeMode) => {
     dispatch({
-      operation: ArtemisReducerOperations.setConsoleExposeMode,
+      operation: ArtemisReducerOperations712.setConsoleExposeMode,
       payload: value,
     });
   };
@@ -93,7 +95,7 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
     setConsoleExpose(exposeConsole);
     setConsoleExposeMode(exposeMode);
     dispatch({
-      operation: ArtemisReducerOperations.setConsoleCredentials,
+      operation: ArtemisReducerOperations712.setConsoleCredentials,
       payload: { adminUser: 'admin', adminPassword: 'admin' },
     });
   }

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -11,19 +11,19 @@ import {
   NumberInput,
   Switch,
   TextInput,
-  InputGroupItem,
 } from '@patternfly/react-core';
 import { FC, useContext, useState } from 'react';
-import {
-  ArtemisReducerOperations,
-  BrokerCreationFormDispatch,
-  BrokerCreationFormState,
-} from '@app/reducers/7.12/reducer';
+import { ArtemisReducerOperations712 as ArtemisReducerOperations712 } from '@app/reducers/7.12/reducer';
 import {
   BrokerProperties,
   BrokerPropertiesList,
 } from './BrokerProperties/BrokerProperties';
 import { useTranslation } from '@app/i18n/i18n';
+import {
+  ArtemisReducerGlobalOperations,
+  BrokerCreationFormDispatch,
+  BrokerCreationFormState,
+} from '@app/reducers/reducer';
 
 export const FormView: FC = () => {
   const { t } = useTranslation();
@@ -34,7 +34,7 @@ export const FormView: FC = () => {
 
   const handleNameChange = (name: string) => {
     dispatch({
-      operation: ArtemisReducerOperations.setBrokerName,
+      operation: ArtemisReducerOperations712.setBrokerName,
       payload: name,
     });
   };
@@ -47,16 +47,17 @@ export const FormView: FC = () => {
   ) => {
     setIsPerBrokerConfig(checked);
   };
-  const [selectedVersion, setSelectedVersion] = useState('7.12');
 
-  const onChangeVersion = (value: string) => {
-    setSelectedVersion(value);
+  const onChangeVersion = (value: '7.12' | '7.13') => {
+    dispatch({
+      operation: ArtemisReducerGlobalOperations.setBrokerVersion,
+      payload: value,
+    });
   };
 
   const options = [
-    { value: 'please choose', label: 'Select a version', disabled: true },
     { value: '7.12', label: 'AMQ 7.12', disabled: false },
-    { value: '8.0', label: 'AMQ 8.0', disabled: true },
+    { value: '7.13', label: 'AMQ 7.13', disabled: false },
   ];
 
   const crName = formState.cr.metadata.name;
@@ -92,18 +93,18 @@ export const FormView: FC = () => {
                 max={1024}
                 onMinus={() =>
                   dispatch({
-                    operation: ArtemisReducerOperations.decrementReplicas,
+                    operation: ArtemisReducerOperations712.decrementReplicas,
                   })
                 }
                 onChange={(event) =>
                   dispatch({
-                    operation: ArtemisReducerOperations.setReplicasNumber,
+                    operation: ArtemisReducerOperations712.setReplicasNumber,
                     payload: Number((event.target as HTMLInputElement).value),
                   })
                 }
                 onPlus={() =>
                   dispatch({
-                    operation: ArtemisReducerOperations.incrementReplicas,
+                    operation: ArtemisReducerOperations712.incrementReplicas,
                   })
                 }
                 inputName="input"
@@ -112,27 +113,25 @@ export const FormView: FC = () => {
                 plusBtnAriaLabel="plus"
               />
             </FormGroup>
-            <FormGroup label={t('Broker Properties')}>
+            <FormGroup label={t('Broker Version')}>
               <InputGroup>
                 <InputGroupText id="broker-version" className=".pf-u-w-initial">
                   {t('Version:')}
                 </InputGroupText>
-                <InputGroupItem>
-                  <FormSelect
-                    value={selectedVersion}
-                    onChange={(_event, value: string) => onChangeVersion(value)}
-                    aria-label="FormSelect Input"
-                  >
-                    {options.map((option, index) => (
-                      <FormSelectOption
-                        isDisabled={option.disabled}
-                        key={index}
-                        value={option.value}
-                        label={option.label}
-                      />
-                    ))}
-                  </FormSelect>
-                </InputGroupItem>
+                <FormSelect
+                  value={formState.brokerVersion}
+                  onChange={(_event, value: any) => onChangeVersion(value)}
+                  aria-label="FormSelect Input"
+                >
+                  {options.map((option, index) => (
+                    <FormSelectOption
+                      isDisabled={option.disabled}
+                      key={index}
+                      value={option.value}
+                      label={option.label}
+                    />
+                  ))}
+                </FormSelect>
               </InputGroup>
             </FormGroup>
             <FormGroup label={t('Per broker config')}>

--- a/src/shared-components/YamlEditorView/YamlEditorView.tsx
+++ b/src/shared-components/YamlEditorView/YamlEditorView.tsx
@@ -14,10 +14,10 @@ import {
 } from '@patternfly/react-core';
 import { Loading } from '@app/shared-components/Loading/Loading';
 import {
-  ArtemisReducerOperations,
+  ArtemisReducerGlobalOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
-} from '../../reducers/7.12/reducer';
+} from '@app/reducers/reducer';
 import YAML, { YAMLParseError } from 'yaml';
 import './YamlEditorView.css';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
@@ -60,7 +60,7 @@ export const YamlEditorView: FC<YamlEditorViewPropTypes> = ({
   const updateModel = (content: string) => {
     try {
       dispatch({
-        operation: ArtemisReducerOperations.setModel,
+        operation: ArtemisReducerGlobalOperations.setModel,
         payload: { model: YAML.parse(content), isSetByUser: true },
       });
       setYamlParserError(undefined);
@@ -184,7 +184,8 @@ export const YamlEditorView: FC<YamlEditorViewPropTypes> = ({
             setCurrentYaml(newContent);
             if (stringedFormState !== newContent) {
               dispatch({
-                operation: ArtemisReducerOperations.setYamlHasUnsavedChanges,
+                operation:
+                  ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges,
               });
             }
           }}


### PR DESCRIPTION
There are now 3 different reducers, the first one takes care of the common operation that can be performed on to the state of the UI, for instance, you'll find in there the elements to configure if the user is using the yaml view or the form view, what version of the broker the user want to deploy and if there are some unsaved changes in the page.

Then there are the other 2 reducers, the one for 7.12 that contains all the logic we had before and the one for 7.13 that will contain extensions for the 7.12 broker.

In the code you'll have to explicitly use the operation from the reducer you want to target, ArtemisGlobalReducerOperations for the interface related one, ArtemisReducerOperations712 for 7.12 and ArtemisReducerOperations713 for 7.13.