### PR TITLE
[NO-ISSUE] FormView: improve style

### DIFF
--- a/src/shared-components/FormView/BrokerProperties/BrokerProperties.tsx
+++ b/src/shared-components/FormView/BrokerProperties/BrokerProperties.tsx
@@ -36,7 +36,7 @@ export const BrokerProperties: FC<BrokerIDProp> = ({
 
   return (
     <Sidebar hasBorder>
-      <SidebarPanel>
+      <SidebarPanel variant="sticky">
         <JumpLinks isVertical aria-label="Broker Config List">
           <JumpLinksItem
             onClick={() => setCurrentConfigItem(ConfigType.acceptors)}
@@ -73,7 +73,7 @@ export const BrokerProperties: FC<BrokerIDProp> = ({
           </JumpLinksItem>
         </JumpLinks>
       </SidebarPanel>
-      <SidebarContent>
+      <SidebarContent hasPadding>
         <GetConfigurationPage
           target={currentConfigItem}
           isPerBrokerConfig={perBrokerProperties}

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -130,7 +130,7 @@ export const FormView: FC = () => {
         {t(' in namespace ')}
         <b>{targetNs}</b>
       </Banner>
-      <PageSection hasOverflowScroll isFilled>
+      <PageSection hasOverflowScroll isFilled type="wizard">
         <BrokerProperties
           brokerId={0}
           perBrokerProperties={false}


### PR DESCRIPTION
The left menu has no background color and sticks in place even when the right column can be scrolled. I have remove the background in the columns to avoid the situation where the light gray areas and white areas where depending on the size of the contained elements.

![image](https://github.com/user-attachments/assets/4f1390af-ce02-4a8e-b354-4d56bf0012fd)

