### PR TITLE
[#21] broker creation: ca don't impact preset

### DIFF
--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -895,6 +895,35 @@ describe('test the creation broker reducer', () => {
       updatedAcceptorName.cr.spec.resourceTemplates[0].patch.spec.tls[0]
         .hosts[0],
     ).toBe('ing.' + 'bob' + '.' + 'bro' + '-0.' + 'space' + '.' + 'tttt.com');
+    // setting the trust secret doesn't change the values
+    const withTrustSecret = reducer712(updatedDomain, {
+      operation: ArtemisReducerOperations712.setAcceptorSecret,
+      payload: {
+        name: 'bob',
+        isCa: true,
+        secret: newOptionObject('toto'),
+      },
+    });
+    expect(withTrustSecret.cr.spec.acceptors[0].sslEnabled).toBe(true);
+    expect(withTrustSecret.cr.spec.acceptors[0].exposeMode).toBe(
+      ExposeMode.ingress,
+    );
+    expect(withTrustSecret.cr.spec.acceptors[0].ingressHost).toBe(
+      'ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)',
+    );
+    expect(withTrustSecret.cr.spec.acceptors[0].sslSecret).toBe(
+      'bro-bob-0-svc-ing-ptls',
+    );
+    expect(withTrustSecret.cr.spec.resourceTemplates).toHaveLength(1);
+    expect(withTrustSecret.cr.spec.resourceTemplates[0].selector.name).toBe(
+      'bro' + '-' + 'bob' + '-0-svc-ing',
+    );
+    expect(withTrustSecret.cr.spec.resourceTemplates[0].selector.name).toBe(
+      'bro' + '-' + 'bob' + '-0-svc-ing',
+    );
+    expect(
+      withTrustSecret.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+    ).toBe('ing.' + 'bob' + '.' + 'bro' + '-0.' + 'space' + '.' + 'tttt.com');
   });
 
   it('test changing number of replicas while in the PEM preset gives the correct number of hosts', () => {

--- a/src/reducers/7.12/reducer.ts
+++ b/src/reducers/7.12/reducer.ts
@@ -620,9 +620,11 @@ export const reducer712: React.Reducer<
       );
       break;
     case ArtemisReducerOperations712.setAcceptorSecret:
-      // when the user sets the acceptor secret manually, remove any linked
-      // annotations
-      clearAcceptorCertManagerConfig(formState.cr, action.payload.name);
+      // when the user sets the acceptor secret manually and that secret is not
+      // a CA, remove any linked annotations
+      if (!action.payload.isCa) {
+        clearAcceptorCertManagerConfig(formState.cr, action.payload.name);
+      }
       // if a cert-manager config was cleared, the sslEnabled flag was set to
       // false, but the user wants to change the secret so reactivate the
       // ssEnabled flag to true.


### PR DESCRIPTION
Setting the trust secret should not have any impact on the preset. There was no warning associated to that field and therefore it used to be a bug.

Now the user can customize the field without loosing the preset if it was set. The unit test has been updated accordingly.