### PR TITLE
Refactor loading and error state management in Broker details and Address details pages

### DIFF
--- a/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
+++ b/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
@@ -123,6 +123,8 @@
   "Delete instance ?": "Delete instance ?",
   "Delete": "Delete",
   "The <strong>{{name}}</strong> instance will be deleted. Applications will no longer have access in this instance.": "The <strong>{{name}}</strong> instance will be deleted. Applications will no longer have access in this instance.",
+  "Error fetching broker": "Error fetching broker",
+  "Could not get broker's CR. An error occurred while retrieving the broker's CR. Please try again later.": "Could not get broker's CR. An error occurred while retrieving the broker's CR. Please try again later.",
   "Acceptors": "Acceptors",
   "Connectors": "Connectors",
   "Console": "Console",

--- a/src/addresses/Address-details/AddressDetails.container.test.tsx
+++ b/src/addresses/Address-details/AddressDetails.container.test.tsx
@@ -113,5 +113,10 @@ describe('AddressDetailsPage', () => {
     );
     await waitForI18n(comp);
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Could not get broker's CR. An error occurred while retrieving the broker's CR. Please try again later.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/addresses/Address-details/AddressDetails.container.tsx
+++ b/src/addresses/Address-details/AddressDetails.container.tsx
@@ -1,11 +1,13 @@
 import { FC } from 'react';
-import { Alert, Title } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core';
 import { useTranslation } from '@app/i18n/i18n';
 import { AddressDetails } from './AddressDetails.component';
 import { AddressDetailsBreadcrumb } from './AddressDetailsBreadcrumb/AddressDetailsBreadcrumb';
 import { useParams } from 'react-router-dom-v5-compat';
 import { JolokiaAuthentication } from '@app/jolokia/components/JolokiaAuthentication';
 import { useGetBrokerCR } from '@app/k8s/customHooks';
+import { Loading } from '@app/shared-components/Loading/Loading';
+import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
 
 export const AddressDetailsPage: FC = () => {
   const { t } = useTranslation();
@@ -22,12 +24,21 @@ export const AddressDetailsPage: FC = () => {
 
   const brokerName = podName?.match(/(.*)-ss-\d+/)?.[1] ?? '';
 
-  const { brokerCr: brokerDetails, error: error } = useGetBrokerCR(
-    brokerName,
-    namespace,
-  );
+  const {
+    brokerCr: brokerDetails,
+    isLoading,
+    error,
+  } = useGetBrokerCR(brokerName, namespace);
 
   const podOrdinal = parseInt(podName.replace(brokerName + '-ss-', ''));
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return <ErrorState />;
+  }
 
   return (
     <JolokiaAuthentication brokerCR={brokerDetails} podOrdinal={podOrdinal}>
@@ -43,7 +54,6 @@ export const AddressDetailsPage: FC = () => {
             {t('Address')} {name}
           </Title>
         </div>
-        {error && <Alert variant="danger" title={error} />}
         <AddressDetails name={name} />
       </>
     </JolokiaAuthentication>

--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -4,8 +4,6 @@ import {
   Tab,
   TabTitleText,
   Title,
-  Spinner,
-  Alert,
   Divider,
   PageSection,
 } from '@patternfly/react-core';
@@ -31,20 +29,18 @@ import {
   ResourceIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { YamlContainer } from './components/yaml/Yaml.container';
+import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
+import { Loading } from '@app/shared-components/Loading/Loading';
 
 type AuthenticatedPageContentPropType = {
   brokerCr: BrokerCR;
   name: string;
   namespace: string;
-  loading: boolean;
-  error: string;
 };
 const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
   brokerCr,
   name,
   namespace,
-  loading: loadingBrokerCr,
-  error: errorBrokerCr,
 }) => {
   const { t } = useTranslation();
 
@@ -52,17 +48,9 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
     {
       href: '',
       name: t('Overview'),
-      component: () =>
-        !loadingBrokerCr ? (
-          <OverviewContainer
-            name={name}
-            namespace={namespace}
-            cr={brokerCr}
-            loading={loadingBrokerCr}
-          />
-        ) : (
-          <Spinner size="md" />
-        ),
+      component: () => (
+        <OverviewContainer name={name} namespace={namespace} cr={brokerCr} />
+      ),
     },
     {
       href: 'clients',
@@ -77,12 +65,7 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
     {
       href: 'yaml',
       name: t('YAML'),
-      component: () =>
-        !loadingBrokerCr ? (
-          <YamlContainer brokerCr={brokerCr} />
-        ) : (
-          <Spinner size="md" />
-        ),
+      component: () => <YamlContainer brokerCr={brokerCr} />,
     },
     {
       href: 'resources',
@@ -142,7 +125,6 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
         </Title>
         <br />
       </PageSection>
-      {errorBrokerCr && <Alert variant="danger" title={errorBrokerCr} />}
       <Divider inset={{ default: 'insetXs' }} />
       <HorizontalNav pages={pages} />
     </>
@@ -153,6 +135,15 @@ export const BrokerDetailsPage: FC = () => {
   const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
 
   const { brokerCr, isLoading, error } = useGetBrokerCR(name, namespace);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return <ErrorState />;
+  }
+
   return (
     <>
       <JolokiaAuthentication brokerCR={brokerCr} podOrdinal={0}>
@@ -160,8 +151,6 @@ export const BrokerDetailsPage: FC = () => {
           brokerCr={brokerCr}
           name={name}
           namespace={namespace}
-          loading={isLoading}
-          error={error}
         />
       </JolokiaAuthentication>
     </>

--- a/src/brokers/broker-details/components/Overview/Overview.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Overview.container.tsx
@@ -31,7 +31,6 @@ import {
   getIssuerForAcceptor,
   getIssuerIngressHostForAcceptor,
 } from '@app/reducers/7.12/reducer';
-import { Loading } from '@app/shared-components/Loading/Loading';
 import {
   Acceptor,
   IssuerResource,
@@ -309,17 +308,14 @@ export type OverviewContainerProps = {
   namespace: string;
   name: string;
   cr: BrokerCR;
-  loading: boolean;
 };
 
 export const OverviewContainer: FC<OverviewContainerProps> = ({
   namespace,
   name,
   cr,
-  loading,
 }) => {
   const { t } = useTranslation();
-  if (loading) return <Loading />;
 
   return (
     <PageSection type="tabs">

--- a/src/shared-components/ErrorState/ErrorState.test.tsx
+++ b/src/shared-components/ErrorState/ErrorState.test.tsx
@@ -1,0 +1,16 @@
+import { render, waitForI18n } from '@app/test-utils';
+import { ErrorState } from './ErrorState';
+
+describe('ErrorState', () => {
+  it('should render ErrorState without crash', async () => {
+    const comp = render(<ErrorState />);
+    await waitForI18n(comp);
+
+    expect(comp.getByText('Error fetching broker')).toBeInTheDocument();
+    expect(
+      comp.getByText(
+        "Could not get broker's CR. An error occurred while retrieving the broker's CR. Please try again later.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/shared-components/ErrorState/ErrorState.tsx
+++ b/src/shared-components/ErrorState/ErrorState.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import { useTranslation } from '@app/i18n/i18n';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+import { ErrorCircleOIcon } from '@patternfly/react-icons';
+
+export const ErrorState: FC = () => {
+  const { t } = useTranslation();
+  return (
+    <EmptyState>
+      <EmptyStateHeader
+        titleText={t('Error fetching broker')}
+        icon={<EmptyStateIcon icon={ErrorCircleOIcon} />}
+        headingLevel="h4"
+      />
+      <EmptyStateBody>
+        {t(
+          "Could not get broker's CR. An error occurred while retrieving the broker's CR. Please try again later.",
+        )}
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};


### PR DESCRIPTION
Centralized the handling of loading and error states in parent components to improve consistency and eliminate unnecessary prop drilling. Removed redundant spinners and error handling logic from child components for cleaner, more maintainable code.

Fixes: [#24](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/24)