### PR TITLE
Fix: Prevent error when conditions are undefined

### DIFF
--- a/src/brokers/broker-details/components/Overview/Conditions/Conditions.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Conditions/Conditions.container.tsx
@@ -10,13 +10,14 @@ type ConditionsContainerProps = {
 
 export const ConditionsContainer: FC<ConditionsContainerProps> = ({ cr }) => {
   const { t } = useTranslation();
+  const conditions = cr.status?.conditions ?? [];
 
   return (
     <PageSection>
       <Title headingLevel="h2" className="pf-u-ml-md pf-u-mb-md">
         {t('Conditions')}
       </Title>
-      <ConditionsList conditions={cr.status?.conditions} />
+      <ConditionsList conditions={conditions} />
     </PageSection>
   );
 };


### PR DESCRIPTION
Added a fallback (?? []) to ensure conditions is always an array. 
Ensures ConditionsRow always receives valid data.

fixes: [#42](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/42)