### PR TITLE
Update the base image to registry.access.redhat.com/ubi9/nodejs20:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-20:latest AS build-image
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS build-image
 
 ### BEGIN REMOTE SOURCE
 # Use the COPY instruction only inside the REMOTE SOURCE block
@@ -26,7 +26,7 @@ RUN yarn install --network-timeout 1000000
 ## Build application
 RUN yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-120:latest
+FROM registry.access.redhat.com/ubi9/nginx-120:latest
 
 COPY --from=build-image /usr/src/app/dist /usr/share/nginx/html
 

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -36,7 +36,7 @@ plugin:
   jobs:
     patchConsoles:
       enabled: true
-      image: "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:e44074f21e0cca6464e50cb6ff934747e0bd11162ea01d522433a1a1ae116103"
+      image: "registry.redhat.io/openshift4/ose-tools-rhel9@sha256:f77fa25b5dd51b135f6bd3a7785dfc23bdfcf65ba12f2a29ea82f57c38d6892a"
       podSecurityContext:
         enabled: true
         runAsNonRoot: true


### PR DESCRIPTION
Currently in our projects the base image of AMQ Broker containers and operator images have been updated to `RHEL9` for FIPS. It makes sense to do the same for the `self-provisioning-plugin` to ensure long-term support, security updates, and compatibility with the latest environments.

fixes: [#52](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/52)