### PR TITLE
Users should always be able to switch to the yaml view

### DIFF
--- a/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
+++ b/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
@@ -26,6 +26,7 @@
   "the broker wont get created": "the broker wont get created",
   "Cancel": "Cancel",
   "Upon reloading, these modifications will be lost.": "Upon reloading, these modifications will be lost.",
+  "Some mandatory fields are missing. Please fill them before proceeding.": "Some mandatory fields are missing. Please fill them before proceeding.",
   "Apply": "Apply",
   "Create": "Create",
   "Reload": "Reload",

--- a/src/brokers/add-broker/AddBroker.component.tsx
+++ b/src/brokers/add-broker/AddBroker.component.tsx
@@ -10,6 +10,7 @@ import {
   FormFieldGroup,
   Modal,
   ModalVariant,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   ArtemisReducerGlobalOperations,
@@ -165,11 +166,7 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
         {t('Upon reloading, these modifications will be lost.')}
       </Modal>
       <Divider />
-      <EditorToggle
-        value={editorType}
-        onChange={onSelectEditorType}
-        isDisabled={navigationDisabled}
-      />
+      <EditorToggle value={editorType} onChange={onSelectEditorType} />
       <Divider />
       {editorType === EditorType.BROKER && <FormView />}
       {editorType === EditorType.YAML && (
@@ -182,20 +179,34 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
       <Form>
         <FormFieldGroup>
           <ActionGroup>
-            <Button
-              variant={ButtonVariant.primary}
-              onClick={() => {
-                if (formValues.editorType === EditorType.YAML) {
-                  setWantsToQuitYamlView(true);
-                  setPendingActionQuittingYAMLView('submit');
-                } else {
-                  onSubmitForFormView();
-                }
-              }}
-              isDisabled={navigationDisabled}
-            >
-              {isUpdatingExisting ? t('Apply') : t('Create')}
-            </Button>
+            {navigationDisabled ? (
+              <Tooltip
+                content={t(
+                  'Some mandatory fields are missing. Please fill them before proceeding.',
+                )}
+                trigger="mouseenter"
+              >
+                <span className="pf-u-pt-sm pf-u-pl-sm pf-u-pb-sm">
+                  <Button variant={ButtonVariant.primary} isDisabled>
+                    {isUpdatingExisting ? t('Apply') : t('Create')}
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : (
+              <Button
+                variant={ButtonVariant.primary}
+                onClick={() => {
+                  if (formValues.editorType === EditorType.YAML) {
+                    setWantsToQuitYamlView(true);
+                    setPendingActionQuittingYAMLView('submit');
+                  } else {
+                    onSubmitForFormView();
+                  }
+                }}
+              >
+                {isUpdatingExisting ? t('Apply') : t('Create')}
+              </Button>
+            )}
             {isUpdatingExisting && (
               <Button
                 variant={ButtonVariant.secondary}


### PR DESCRIPTION
Users should always be able to switch to the YAML editor. However, if mandatory fields are missing, they cannot create the broker. They must fill in the required fields before proceeding with broker creation.

Added Tooltip to provide message when the create button is disabled.
![Screenshot from 2025-02-25 10-14-02](https://github.com/user-attachments/assets/125c58e1-55c3-4609-8b66-85935d5cc894)
