### PR TITLE
Fix: missing exposeMode in Broker CR causes Jolokia endpoint hostname to be 'undefined' 

### DIFF
--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -666,6 +666,15 @@ describe('test the creation broker reducer', () => {
     const initialState = newBroker712CR('namespace');
     const newState = reducer712(initialState, {
       operation: ArtemisReducerOperations712.setConsoleExposeMode,
+      payload: ExposeMode.route,
+    });
+    expect(newState.cr.spec.console.exposeMode).toBe(ExposeMode.route);
+  });
+
+  it('test setConsoleExposeMode', () => {
+    const initialState = newBroker712CR('namespace');
+    const newState = reducer712(initialState, {
+      operation: ArtemisReducerOperations712.setConsoleExposeMode,
       payload: ExposeMode.ingress,
     });
     expect(newState.cr.spec.console.exposeMode).toBe(ExposeMode.ingress);

--- a/src/reducers/7.12/reducer.ts
+++ b/src/reducers/7.12/reducer.ts
@@ -23,6 +23,7 @@ export const newBroker712CR = (namespace: string): FormState712 => {
       ingressDomain: '',
       console: {
         expose: true,
+        exposeMode: ExposeMode.route,
       },
       deploymentPlan: {
         image: 'placeholder',


### PR DESCRIPTION
Fixed Jolokia endpoint hostname to be 'undefined' issue by updating the reducer to include a default way to add exposeMode in the console.

And also added test case to verify that the value is set correctly.

 Fixes: [Issue#90](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/90)