### PR TITLE
Migrated deprecated PatternFly components in AddressDetails.component to v5

### DIFF
--- a/src/addresses/Address-details/AddressDetails.component.tsx
+++ b/src/addresses/Address-details/AddressDetails.component.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext, useState } from 'react';
 import { Thead, Tr, Th, Tbody } from '@patternfly/react-table';
-import { Table } from '@patternfly/react-table/deprecated';
+import { Table } from '@patternfly/react-table';
 import {
   Spinner,
   Bullseye,


### PR DESCRIPTION
Migrated deprecated PatternFly components in AddressDetails.component.tsx to pf-v5.

fixes: [issue#67](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/67)