### PR TITLE
Migrate deprecated PatternFly components in AddressDetailsRow.test.tsx to v5

### DIFF
--- a/src/addresses/Address-details/AddressDetailsRow.test.tsx
+++ b/src/addresses/Address-details/AddressDetailsRow.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from '@app/test-utils';
 import { AddressDetailsRow } from './AddressDetailsRow';
 import { ComponentAttribute } from '@app/openapi/jolokia/requests';
-import { Tbody } from '@patternfly/react-table';
-import { Table } from '@patternfly/react-table/deprecated';
+import { Table, Tbody } from '@patternfly/react-table';
 
 const mockAttribute: ComponentAttribute = {
   request: {


### PR DESCRIPTION
Migrated deprecated PatternFly components in AddressDetailsRow.test.tsx to v5.

fixes: [#68](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/68) 