### PR TITLE
[#97] horizontalNav: no anonymous components

### DIFF
--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -47,9 +47,7 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
     {
       href: '',
       name: t('Overview'),
-      component: () => (
-        <OverviewContainer name={name} namespace={namespace} cr={brokerCr} />
-      ),
+      component: OverviewContainer,
     },
     {
       href: 'clients',
@@ -64,7 +62,7 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
     {
       href: 'yaml',
       name: t('YAML'),
-      component: () => <YamlContainer brokerCr={brokerCr} />,
+      component: YamlContainer,
     },
     {
       href: 'resources',
@@ -117,13 +115,13 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
 
   return (
     <>
-        <BrokerDetailsBreadcrumb name={name} namespace={namespace} />
-        <Title headingLevel="h1" className="pf-u-ml-md">
-          <ResourceIcon kind="broker.amq.io~v1beta1~ActiveMQArtemis" /> {name}
-        </Title>
-        <br />
+      <BrokerDetailsBreadcrumb name={name} namespace={namespace} />
+      <Title headingLevel="h1" className="pf-u-ml-md">
+        <ResourceIcon kind="broker.amq.io~v1beta1~ActiveMQArtemis" /> {name}
+      </Title>
+      <br />
       <Divider inset={{ default: 'insetXs' }} />
-      <HorizontalNav pages={pages} />
+      <HorizontalNav resource={brokerCr} pages={pages} />
     </>
   );
 };

--- a/src/brokers/broker-details/components/Overview/Overview.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Overview.container.tsx
@@ -42,7 +42,10 @@ import {
 import { Metrics } from './Metrics/Metrics';
 import { useTranslation } from '@app/i18n/i18n';
 import { ConditionsContainer } from '@app/brokers/broker-details/components/Overview/Conditions/Conditions.container';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { Loading } from '@app/shared-components/Loading/Loading';
+import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
+import { useGetBrokerCR } from '@app/k8s/customHooks';
 
 const useGetIssuerCa = (
   cr: BrokerCR,
@@ -342,18 +345,18 @@ const Labels: FC<IssuerSecretsDownloaderProps> = ({ cr }) => {
   );
 };
 
-export type OverviewContainerProps = {
-  namespace: string;
-  name: string;
-  cr: BrokerCR;
-};
-
-export const OverviewContainer: FC<OverviewContainerProps> = ({
-  namespace,
-  name,
-  cr,
-}) => {
+export const OverviewContainer: FC = () => {
   const { t } = useTranslation();
+  const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
+
+  const { brokerCr: cr, isLoading, error } = useGetBrokerCR(name, namespace);
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return <ErrorState />;
+  }
 
   return (
     <PageSection type="tabs">

--- a/src/brokers/broker-details/components/yaml/Yaml.container.test.tsx
+++ b/src/brokers/broker-details/components/yaml/Yaml.container.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@app/test-utils';
 import { YamlContainer } from './Yaml.container';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { useGetBrokerCR } from '@app/k8s/customHooks';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   ResourceYAMLEditor: jest.fn(() => <div>Mocked ResourceYAMLEditor</div>),
@@ -11,8 +12,13 @@ jest.mock('react-router-dom-v5-compat', () => ({
   useNavigate: jest.fn(),
 }));
 
+jest.mock('@app/k8s/customHooks', () => ({
+  useGetBrokerCR: jest.fn(),
+}));
+
 const mockUseParams = useParams as jest.Mock;
 const mockUseNavigate = useNavigate as jest.Mock;
+const mockUseGetBrokerCR = useGetBrokerCR as jest.Mock;
 
 describe('YamlContainer', () => {
   beforeEach(() => {
@@ -24,30 +30,29 @@ describe('YamlContainer', () => {
     });
 
     mockUseNavigate.mockReturnValue(jest.fn());
+    mockUseGetBrokerCR.mockReturnValue({
+      apiVersion: 'broker.amq.io/v1beta1',
+      kind: 'ActiveMQArtemis',
+      metadata: {
+        creationTimestamp: '2024-12-05T07:41:45Z',
+        name: 'test-1',
+        namespace: 'test-namespace',
+      },
+      spec: {
+        adminPassword: 'admin',
+        adminUser: 'admin',
+        console: { expose: true },
+        deploymentPlan: {
+          image: 'placeholder',
+          requireLogin: false,
+          size: 2,
+        },
+      },
+    });
   });
 
-  const mockBrokerCr = {
-    apiVersion: 'broker.amq.io/v1beta1',
-    kind: 'ActiveMQArtemis',
-    metadata: {
-      creationTimestamp: '2024-12-05T07:41:45Z',
-      name: 'ex-aao',
-      namespace: 'default',
-    },
-    spec: {
-      adminPassword: 'admin',
-      adminUser: 'admin',
-      console: { expose: true },
-      deploymentPlan: {
-        image: 'placeholder',
-        requireLogin: false,
-        size: 2,
-      },
-    },
-  };
-
   it('should render the YamlContainer component successfully', () => {
-    render(<YamlContainer brokerCr={mockBrokerCr} />);
+    render(<YamlContainer />);
     expect(
       screen.getByText('This YAML view is in read-only mode.'),
     ).toBeInTheDocument();
@@ -60,7 +65,7 @@ describe('YamlContainer', () => {
     const navigate = jest.fn();
     mockUseNavigate.mockReturnValue(navigate);
 
-    render(<YamlContainer brokerCr={mockBrokerCr} />);
+    render(<YamlContainer />);
 
     fireEvent.click(screen.getByRole('button', { name: /edit form/i }));
 

--- a/src/brokers/broker-details/components/yaml/Yaml.container.tsx
+++ b/src/brokers/broker-details/components/yaml/Yaml.container.tsx
@@ -5,15 +5,21 @@ import YAML from 'yaml';
 import { Alert, AlertVariant, Button } from '@patternfly/react-core';
 import { useTranslation } from '@app/i18n/i18n';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { useGetBrokerCR } from '@app/k8s/customHooks';
+import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
 
-type YamlViewProps = {
-  brokerCr: object;
-};
-
-const YamlContainer: FC<YamlViewProps> = ({ brokerCr }) => {
+const YamlContainer: FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
+  const { brokerCr, isLoading, error } = useGetBrokerCR(name, namespace);
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return <ErrorState />;
+  }
   const onClickEditYaml = () => {
     const currentPath = window.location.pathname;
     navigate(


### PR DESCRIPTION
The horizontalNav only supports named components. Passing an anonymous one as the side effect of triggering unwanted redraws. This was the reason of the observed flickering on the issue #97.

Fixes #97