### PR TITLE
Use correct API group for Ingress

### DIFF
--- a/src/jolokia/customHooks.ts
+++ b/src/jolokia/customHooks.ts
@@ -146,7 +146,7 @@ export const useGetEndpointData = (
   const [ingresses] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     groupVersionKind: {
-      group: 'route.openshift.io',
+      group: 'networking.k8s.io',
       kind: 'Ingress',
       version: 'v1',
     },


### PR DESCRIPTION
Updated Ingress to point to the correct group address.

fixes: [ISSUE#105](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/105)