### PR TITLE
[NO-ISSUE] include documentation about pki

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,46 @@ its functionalities.
 
 Navigate to the operatorHub on the console and search for `Cert-manager`.
 
+#### Bootstraping a cluster issuer
+
+Apply this:
+
+```yaml
+oc apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-selfsigned-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: my-selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: my-ca-issuer
+spec:
+  ca:
+    secretName: root-secret
+EOF
+```
+
 ### Running the plugin
 
 #### Download the secrets so that the bridge can authenticate the user with the api server backend


### PR DESCRIPTION
When setting up the cluster for the first time users might not have a pki already and will be missing a cluster issuer to generate certs.