### PR TITLE
Implement filtering option for security roles

### DIFF
--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/SecurityRules.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/SecurityRules.tsx
@@ -11,6 +11,7 @@ import {
   InputGroupItem,
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
+  SearchInput,
 } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import { useTranslation } from '@app/i18n/i18n';
@@ -100,6 +101,9 @@ export const SecurityRoles: FC = () => {
   const { cr } = useContext(BrokerCreationFormState);
   const securityRoles = getSecurityRoles(cr);
   const dispatch = useContext(BrokerCreationFormDispatch);
+
+  const [filterValue, setFilterValue] = useState<string>('');
+
   const addNewSecurityRule = (key: string, value: string) => {
     const newSecurityRoles = new Map([...securityRoles, [key, value]]);
     dispatch({
@@ -122,9 +126,27 @@ export const SecurityRoles: FC = () => {
         />
       }
     >
-      {Array.from(securityRoles).map(([key, value]) => (
-        <SecurityRule key={key + value} name={key} value={value} />
-      ))}
+      <SearchInput
+        placeholder={t('Filter by security roles...')}
+        value={filterValue}
+        onChange={(_event, value) => setFilterValue(value)}
+        onClear={() => setFilterValue('')}
+      />
+
+      {Array.from(securityRoles)
+        .filter(([key]) => {
+          if (!filterValue) return true;
+
+          try {
+            const regex = new RegExp(filterValue, 'i');
+            return regex.test(key);
+          } catch {
+            return key.toLowerCase().includes(filterValue.toLowerCase());
+          }
+        })
+        .map(([key, value]) => (
+          <SecurityRule key={key + value} name={key} value={value} />
+        ))}
       <Button
         variant="link"
         onClick={() =>


### PR DESCRIPTION
Since security roles are very long list, added a filtering option to make roles easier to find.

<img width="1910" height="939" alt="Screenshot From 2025-09-03 12-42-54" src="https://github.com/user-attachments/assets/1e9500f5-f49e-4b07-a4a8-79e81981c747" />


fixes: [Issue#53](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/53)