### PR TITLE
Chore/remove lodash from prometheus 125

### DIFF
--- a/src/brokers/broker-details/components/Overview/Metrics/utils/data-utils.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/data-utils.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash-es';
 import { getType } from './units';
 // Types
 export type DataPoint<X = Date | number | string> = {
@@ -33,12 +32,12 @@ const bestUnit = (
   );
 
   const bestLevel = flattenDataPoints.reduce((maxUnit, point) => {
-    const index = Math.floor(log(_.get(type, 'divisor', 1024), point.y));
+    const index = Math.floor(log(type?.divisor ?? 1024, point.y));
     const unitIndex =
       index >= type.units.length ? type.units.length - 1 : index;
     return maxUnit < unitIndex ? unitIndex : maxUnit;
   }, -1);
-  return _.get(type, ['units', bestLevel]);
+  return type?.units?.[bestLevel];
 };
 
 // Array based processor

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/prometheus.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/prometheus.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash-es';
-
 // Conversions between units and milliseconds
 const s = 1000;
 const m = s * 60;
@@ -18,19 +16,19 @@ const units: { [key: string]: number } = { w, d, h, m, s };
  * ```
  */
 export const formatPrometheusDuration = (ms: number) => {
-  if (!_.isFinite(ms) || ms < 0) {
+  if (!Number.isFinite(ms) || ms < 0) {
     return '';
   }
   let remaining = ms;
   let str = '';
-  _.each(units, (factor, unit) => {
+  Object.entries(units).forEach(([unit, factor]) => {
     const n = Math.floor(remaining / factor);
     if (n > 0) {
       str += `${n}${unit} `;
       remaining -= n * factor;
     }
   });
-  return _.trim(str);
+  return str.trim();
 };
 
 /**
@@ -48,9 +46,10 @@ export const parsePrometheusDuration = (duration: string): number => {
       .trim()
       .split(/\s+/)
       .map((p) => p.match(/^(\d+)([wdhms])$/));
-    return _.sumBy(
-      parts,
-      (p: RegExpMatchArray | null) => parseInt(p[1], 10) * units[p[2]],
+    return parts.reduce(
+      (sum, p: RegExpMatchArray | null) =>
+        sum + parseInt(p[1], 10) * units[p[2]],
+      0,
     );
   } catch (ignored) {
     // Invalid duration format


### PR DESCRIPTION
### Summary
This PR removes `lodash-es` usage from `prometheus.ts` and replaces it with modern JavaScript equivalents.

### Closes Issues
Fixes #125 

### Why
- Lodash adds unnecessary bundle size (~70KB).
- All used lodash functions (`isFinite`, `each`, `trim`, `sumBy`) have direct native JS replacements.
- Improves readability and reduces dependencies.

### Changes
- Removed `import _ from 'lodash-es'`
- Replaced:
  - `_.isFinite` → `Number.isFinite`
  - `_.each` → `Object.entries().forEach`
  - `_.trim` → `String.prototype.trim`
  - `_.sumBy` → `Array.prototype.reduce`
- Kept existing functionality intact.

### How to Test
1. Run unit tests:
   ```bash
   npm test -- prometheus.test
   
2. Verify:

- formatPrometheusDuration(ms) correctly formats ms into strings (e.g., 65000 → "1m 5s").
- parsePrometheusDuration("1m 5s") correctly parses back to ms (65000).
- Edge cases (invalid inputs, negatives) return expected results.

3. Acceptance Criteria
- [x] No lodash imports in prometheus.ts
- [x] All lodash functions replaced with native JS
- [x] Tests pass
- [x] Functionality preserved
