### PR TITLE
[NO-ISSUE] fix webpack websocket config in tls mode

### DIFF
--- a/webpack.config.tls.ts
+++ b/webpack.config.tls.ts
@@ -68,7 +68,15 @@ const config: Configuration = {
   devServer: {
     static: './dist',
     port: 9444,
-    https: true,
+    host: '0.0.0.0',
+    server: {
+      type: 'https',
+      options: {
+        key: path.resolve(__dirname, 'console-cert/domain.key'),
+        cert: path.resolve(__dirname, 'console-cert/domain.crt'),
+        ca: path.resolve(__dirname, 'console-cert/rootCA.crt'),
+      },
+    },
     // Allow bridge running in a container to connect to the plugin dev server.
     allowedHosts: 'all',
     headers: {
@@ -79,6 +87,13 @@ const config: Configuration = {
     },
     devMiddleware: {
       writeToDisk: true,
+    },
+    client: {
+      webSocketURL: {
+        hostname: 'localhost',
+        port: 9444,
+        protocol: 'wss',
+      },
     },
   },
   plugins: [

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,4 +1,4 @@
-/z* eslint-env node */;
+/* eslint-env node */
 
 import * as path from 'path';
 import { DefinePlugin, Configuration as WebpackConfiguration } from 'webpack';


### PR DESCRIPTION
The websocket config was preventing the hot reload of the pages when in development. This commit fixes that by including the tls certificates required to open a secured connection to the weback server.