### PR TITLE
Improve type safety in metrics system by refining TypeScript types and removing all `any` types

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,6 +30,7 @@ rules:
   unused-imports/no-unused-imports-ts: 2
   no-console: 'error'
   no-alert: 'error'
+  no-explicit-any: 'error'
 settings:
   react:
     version: detect
@@ -37,3 +38,7 @@ overrides:
   - files: ['./src/openapi/*']
     rules:
       no-console: 'off'
+  - files: ['./src/k8s/types.ts']
+    rules:
+      no-explicit-any: 'off'
+  

--- a/src/brokers/broker-details/components/BrokerDetailsBreadcrumb/BrokerDetailsBreadcrumb.tsx
+++ b/src/brokers/broker-details/components/BrokerDetailsBreadcrumb/BrokerDetailsBreadcrumb.tsx
@@ -29,7 +29,7 @@ const BrokerDetailsBreadcrumb: FC<BrokerDetailsBreadcrumbProps> = ({
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [_loadError, setLoadError] = useState<any>();
+  const [_loadError, setLoadError] = useState<Error | null>(null);
   const navigate = useNavigate();
 
   const redirectPath = `/k8s/ns/${namespace}/brokers`;

--- a/src/brokers/broker-details/components/Overview/Metrics/components/QueryBrowser/QueryBrowser.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/QueryBrowser/QueryBrowser.tsx
@@ -42,9 +42,8 @@ export type QueryBrowserProps = {
   formatSeriesTitle?: FormatSeriesTitle;
   yTickFormat: (v: number) => string;
   processedData?: DataPoint<string | number | Date>[][];
-  // data: GraphSeries[]
   metricsType?: 'memory' | 'cpu';
-  label?: any;
+  label?: string;
   ariaTitle: string;
 };
 

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/format.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/format.ts
@@ -99,7 +99,7 @@ export const formatSeriesValues = (
   return newValues;
 };
 
-export const xAxisTickFormat = (span: number): ((tick: any) => string) => {
+export const xAxisTickFormat = (span: number): ((tick: number) => string) => {
   return (tick) => {
     if (span > parsePrometheusDuration('1d')) {
       // Add a newline between the date and time so tick labels don't overlap.

--- a/src/brokers/broker-details/components/Overview/Overview.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Overview.container.tsx
@@ -134,7 +134,7 @@ const HelpConnectAcceptor: FC<HelperConnectAcceptorProps> = ({
     navigator.clipboard.writeText(text.toString());
   };
 
-  const onClick = (_event: any, text: string) => {
+  const onClick = (_event: React.MouseEvent, text: string) => {
     clipboardCopyFunc(text);
     setCopied(true);
   };

--- a/src/brokers/broker-details/components/Resources/components/ResourcesList.tsx
+++ b/src/brokers/broker-details/components/Resources/components/ResourcesList.tsx
@@ -94,7 +94,7 @@ export const ResourcesTable: FC<ResourcesTableProps> = ({ data }) => {
 type ResourcesListProps = {
   brokerResources: BrokerCR[];
   loaded: boolean;
-  loadError: any;
+  loadError: Error | null;
 };
 
 const ResourcesList: FC<ResourcesListProps> = ({ brokerResources, loaded }) => {

--- a/src/brokers/broker-details/components/broker-pods/components/PodList.test.tsx
+++ b/src/brokers/broker-details/components/broker-pods/components/PodList.test.tsx
@@ -6,23 +6,11 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   ListPageHeader: jest.fn(({ title }) => <div>{title}</div>),
   ListPageBody: jest.fn(({ children }) => <div>{children}</div>),
   ListPageFilter: jest.fn(() => <div>ListPageFilter</div>),
-  VirtualizedTable: jest.fn(({ Row, data, columns }) => (
-    <div>
-      <div>VirtualizedTable</div>
-      {data.map((item: any, index: number) => (
-        <Row
-          key={index}
-          obj={item}
-          activeColumnIDs={columns.map((col: any) => col.id)}
-        />
-      ))}
-    </div>
-  )),
   useListPageFilter: jest.fn(),
 }));
 
-jest.mock('./PodRow', () => ({
-  PodRow: jest.fn(() => <div>PodRow Component</div>),
+jest.mock('./PodsTable', () => ({
+  PodsTable: jest.fn(() => <div>PodsTable component</div>),
 }));
 
 describe('PodsList', () => {
@@ -65,15 +53,8 @@ describe('PodsList', () => {
     expect(screen.getByText('ListPageFilter')).toBeInTheDocument();
   });
 
-  it('should render the VirtualizedTable', () => {
+  it('should render the PodsTable', () => {
     render(<PodsList {...mockPodsListProps} />);
-    expect(screen.getByText('VirtualizedTable')).toBeInTheDocument();
-  });
-
-  it('should render PodRow components within the VirtualizedTable', () => {
-    render(<PodsList {...mockPodsListProps} />);
-
-    const podRowElements = screen.getAllByText('PodRow Component');
-    expect(podRowElements.length).toBe(mockPodsListProps.brokerPods.length);
+    expect(screen.getByText('PodsTable component')).toBeInTheDocument();
   });
 });

--- a/src/brokers/broker-details/components/broker-pods/components/PodList.tsx
+++ b/src/brokers/broker-details/components/broker-pods/components/PodList.tsx
@@ -2,77 +2,24 @@ import { FC } from 'react';
 import {
   ListPageHeader,
   ListPageBody,
-  VirtualizedTable,
   useListPageFilter,
   ListPageFilter,
-  TableColumn,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from '@app/i18n/i18n';
 import { BrokerCR } from '@app/k8s/types';
-import { PodRow } from './PodRow';
-
-type PodsTableProps = {
-  data: BrokerCR[];
-  unfilteredData: BrokerCR[];
-  loaded: boolean;
-  loadError: any;
-};
-
-const PodsTable: FC<PodsTableProps> = ({
-  data,
-  unfilteredData,
-  loaded,
-  loadError,
-}) => {
-  const columns: TableColumn<BrokerCR>[] = [
-    {
-      title: 'Name',
-      id: 'name',
-    },
-    {
-      title: 'Status',
-      id: 'status',
-    },
-    {
-      title: 'Ready',
-      id: 'ready',
-    },
-    {
-      title: 'Restarts',
-      id: 'restarts',
-    },
-    {
-      title: 'Created',
-      id: 'created',
-    },
-  ];
-
-  return (
-    <VirtualizedTable<BrokerCR>
-      data={data}
-      unfilteredData={unfilteredData}
-      loaded={loaded}
-      loadError={loadError}
-      columns={columns}
-      Row={({ obj, activeColumnIDs, rowData }) => (
-        <PodRow
-          obj={obj}
-          rowData={rowData}
-          activeColumnIDs={activeColumnIDs}
-          columns={columns}
-        />
-      )}
-    />
-  );
-};
+import { PodsTable } from './PodsTable';
 
 export type PodsListProps = {
   brokerPods: BrokerCR[];
   loaded: boolean;
-  loadError: any;
+  loadError: Error | null;
 };
 
-const PodsList: FC<PodsListProps> = ({ brokerPods, loaded, loadError }) => {
+export const PodsList: FC<PodsListProps> = ({
+  brokerPods,
+  loaded,
+  loadError,
+}) => {
   const { t } = useTranslation();
   const [data, filteredData, onFilterChange] = useListPageFilter(brokerPods);
 
@@ -95,5 +42,3 @@ const PodsList: FC<PodsListProps> = ({ brokerPods, loaded, loadError }) => {
     </>
   );
 };
-
-export { PodsList };

--- a/src/brokers/broker-details/components/broker-pods/components/PodRow.tsx
+++ b/src/brokers/broker-details/components/broker-pods/components/PodRow.tsx
@@ -5,7 +5,7 @@ import {
   TableColumn,
   Timestamp,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { BrokerCR } from '@app/k8s/types';
+import { BrokerCR, ContainerStatus } from '@app/k8s/types';
 import { Link } from 'react-router-dom-v5-compat';
 
 export type PodRowProps = RowProps<BrokerCR> & {
@@ -19,9 +19,11 @@ export const PodRow: FC<PodRowProps> = ({ obj, activeColumnIDs, columns }) => {
   } = obj;
 
   const readyCount = status?.containerStatuses
-    ? status.containerStatuses.filter((container: any) => container.ready)
-        .length
+    ? status.containerStatuses.filter(
+        (container: ContainerStatus) => container.ready,
+      ).length
     : 0;
+
   const totalCount = status?.containerStatuses?.length || 0;
   const podReadiness = `${readyCount}/${totalCount}`;
 

--- a/src/brokers/broker-details/components/broker-pods/components/PodsTable.test.tsx
+++ b/src/brokers/broker-details/components/broker-pods/components/PodsTable.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@app/test-utils';
+import { PodsTable } from './PodsTable';
+import { BrokerCR } from '@app/k8s/types';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  VirtualizedTable: jest.fn(({ Row, data, columns }) => (
+    <div data-testid="virtualized-table">
+      {data.map((item: BrokerCR, index: number) => (
+        <Row
+          key={index}
+          obj={item}
+          activeColumnIDs={columns.map((col: TableColumn<BrokerCR>) => col.id)}
+          rowData={item}
+        />
+      ))}
+    </div>
+  )),
+}));
+
+jest.mock('./PodRow', () => ({
+  PodRow: jest.fn(() => <div data-testid="pod-row">PodRow component</div>),
+}));
+
+describe('PodsTable', () => {
+  const mockData: BrokerCR[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: 'test-1',
+        namespace: 'default',
+        creationTimestamp: '2025-11-14T00:00:00Z',
+      },
+      status: {
+        phase: 'Running',
+      },
+    },
+  ];
+
+  it('should renders VirtualizedTable and PodRow', () => {
+    render(
+      <PodsTable
+        data={mockData}
+        unfilteredData={mockData}
+        loaded={true}
+        loadError={null}
+      />,
+    );
+
+    expect(screen.getByTestId('virtualized-table')).toBeInTheDocument();
+    expect(screen.getByText('PodRow component')).toBeInTheDocument();
+  });
+});

--- a/src/brokers/broker-details/components/broker-pods/components/PodsTable.tsx
+++ b/src/brokers/broker-details/components/broker-pods/components/PodsTable.tsx
@@ -1,0 +1,62 @@
+import { FC } from 'react';
+import {
+  VirtualizedTable,
+  TableColumn,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { PodRow } from './PodRow';
+import { BrokerCR } from '@app/k8s/types';
+
+export type PodsTableProps = {
+  data: BrokerCR[];
+  unfilteredData: BrokerCR[];
+  loaded: boolean;
+  loadError: Error | null;
+};
+
+export const PodsTable: FC<PodsTableProps> = ({
+  data,
+  unfilteredData,
+  loaded,
+  loadError,
+}) => {
+  const columns: TableColumn<BrokerCR>[] = [
+    {
+      title: 'Name',
+      id: 'name',
+    },
+    {
+      title: 'Status',
+      id: 'status',
+    },
+    {
+      title: 'Ready',
+      id: 'ready',
+    },
+    {
+      title: 'Restarts',
+      id: 'restarts',
+    },
+    {
+      title: 'Created',
+      id: 'created',
+    },
+  ];
+
+  return (
+    <VirtualizedTable<BrokerCR>
+      data={data}
+      unfilteredData={unfilteredData}
+      loaded={loaded}
+      loadError={loadError}
+      columns={columns}
+      Row={({ obj, activeColumnIDs, rowData }) => (
+        <PodRow
+          obj={obj}
+          rowData={rowData}
+          activeColumnIDs={activeColumnIDs}
+          columns={columns}
+        />
+      )}
+    />
+  );
+};

--- a/src/brokers/view-brokers/components/BrokersList/BrokersList.test.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokersList.test.tsx
@@ -9,23 +9,11 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   )),
   ListPageBody: jest.fn(({ children }) => <div>{children}</div>),
   ListPageFilter: jest.fn(() => <div>ListPageFilter</div>),
-  VirtualizedTable: jest.fn(({ Row, data, columns }) => (
-    <div>
-      <div>VirtualizedTable</div>
-      {data.map((item: any, index: number) => (
-        <Row
-          key={index}
-          obj={item}
-          activeColumnIDs={columns.map((col: any) => col.id)}
-        />
-      ))}
-    </div>
-  )),
   useListPageFilter: jest.fn(),
 }));
 
-jest.mock('./BrokerRow', () => ({
-  BrokerRow: jest.fn(() => <div>BrokerRow Component</div>),
+jest.mock('./BrokersTable', () => ({
+  BrokersTable: jest.fn(() => <div>BrokersTable component</div>),
 }));
 
 describe('BrokersList', () => {
@@ -110,15 +98,8 @@ describe('BrokersList', () => {
     expect(screen.getByText('ListPageFilter')).toBeInTheDocument();
   });
 
-  it('should render the VirtualizedTable', () => {
+  it('should render the BrokersTable', () => {
     render(<BrokersList {...mockBrokersListProps} />);
-    expect(screen.getByText('VirtualizedTable')).toBeInTheDocument();
-  });
-
-  it('should render BrokerRow component within the VirtualizedTable', () => {
-    render(<BrokersList {...mockBrokersListProps} />);
-
-    const BrokerRowElements = screen.getAllByText('BrokerRow Component');
-    expect(BrokerRowElements.length).toBe(mockBrokersListProps.brokers.length);
+    expect(screen.getByText('BrokersTable component')).toBeInTheDocument();
   });
 });

--- a/src/brokers/view-brokers/components/BrokersList/BrokersList.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokersList.tsx
@@ -2,83 +2,14 @@ import { FC } from 'react';
 import {
   ListPageHeader,
   ListPageBody,
-  VirtualizedTable,
   useListPageFilter,
   ListPageFilter,
-  TableColumn,
   ListPageCreateLink,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { BrokerRow, BrokerRowProps } from './BrokerRow';
+import { BrokerRowProps } from './BrokerRow';
 import { useTranslation } from '@app/i18n/i18n';
 import { BrokerCR } from '@app/k8s/types';
-
-type BrokersTableProps = Pick<
-  BrokerRowProps,
-  'onOpenModal' | 'onEditBroker'
-> & {
-  data: BrokerCR[];
-  unfilteredData: BrokerCR[];
-  loaded: boolean;
-  loadError: any;
-};
-
-const BrokersTable: FC<BrokersTableProps> = ({
-  data,
-  unfilteredData,
-  loaded,
-  loadError,
-  onOpenModal,
-  onEditBroker,
-}) => {
-  const { t } = useTranslation();
-
-  const columns: TableColumn<BrokerCR>[] = [
-    {
-      title: t('Name'),
-      id: 'name',
-    },
-    {
-      title: t('Ready'),
-      id: 'ready',
-    },
-    {
-      title: t('Conditions'),
-      id: 'conditions',
-    },
-    {
-      title: t('Size'),
-      id: 'Size',
-    },
-    {
-      title: t('Create'),
-      id: 'created',
-    },
-    {
-      title: '',
-      id: 'action',
-    },
-  ];
-
-  return (
-    <VirtualizedTable<BrokerCR>
-      data={data}
-      unfilteredData={unfilteredData}
-      loaded={loaded}
-      loadError={loadError}
-      columns={columns}
-      Row={({ obj, activeColumnIDs, rowData }) => (
-        <BrokerRow
-          obj={obj}
-          rowData={rowData}
-          activeColumnIDs={activeColumnIDs}
-          columns={columns}
-          onOpenModal={onOpenModal}
-          onEditBroker={onEditBroker}
-        />
-      )}
-    />
-  );
-};
+import { BrokersTable } from './BrokersTable';
 
 export type BrokersListProps = Pick<
   BrokerRowProps,
@@ -86,11 +17,11 @@ export type BrokersListProps = Pick<
 > & {
   brokers: BrokerCR[];
   loaded: boolean;
-  loadError: any;
+  loadError: Error | null;
   namespace: string;
 };
 
-const BrokersList: FC<BrokersListProps> = ({
+export const BrokersList: FC<BrokersListProps> = ({
   brokers,
   loaded,
   loadError,
@@ -130,5 +61,3 @@ const BrokersList: FC<BrokersListProps> = ({
     </>
   );
 };
-
-export { BrokersList };

--- a/src/brokers/view-brokers/components/BrokersList/BrokersTable.test.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokersTable.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@app/test-utils';
+import { BrokersTable } from './BrokersTable';
+import { BrokerCR } from '@app/k8s/types';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  VirtualizedTable: jest.fn(({ Row, data, columns }) => (
+    <div data-testid="virtualized-table">
+      {data.map((item: BrokerCR, index: number) => (
+        <Row
+          key={index}
+          obj={item}
+          activeColumnIDs={columns.map((col: TableColumn<BrokerCR>) => col.id)}
+          rowData={item}
+        />
+      ))}
+    </div>
+  )),
+}));
+
+jest.mock('./BrokerRow', () => ({
+  BrokerRow: jest.fn(() => (
+    <div data-testid="broker-row">BrokerRow Component</div>
+  )),
+}));
+
+describe('BrokersTable', () => {
+  const mockData: BrokerCR[] = [
+    {
+      apiVersion: 'broker.amq.io/v1beta1',
+      kind: 'ActiveMQArtemis',
+      metadata: {
+        name: 'test-broker',
+        namespace: 'default',
+        creationTimestamp: '2025-11-14T12:05:09Z',
+      },
+      spec: {
+        deploymentPlan: {
+          image: 'placeholder',
+          requireLogin: false,
+          size: 1,
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    },
+  ];
+
+  const onOpenModal = jest.fn();
+  const onEditBroker = jest.fn();
+
+  it('should renders VirtualizedTable and BrokerRow', () => {
+    render(
+      <BrokersTable
+        data={mockData}
+        unfilteredData={mockData}
+        loaded={true}
+        loadError={null}
+        onOpenModal={onOpenModal}
+        onEditBroker={onEditBroker}
+      />,
+    );
+
+    expect(screen.getByTestId('virtualized-table')).toBeInTheDocument();
+    expect(screen.getByText('BrokerRow Component')).toBeInTheDocument();
+  });
+});

--- a/src/brokers/view-brokers/components/BrokersList/BrokersTable.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokersTable.tsx
@@ -1,0 +1,76 @@
+import { FC } from 'react';
+import { BrokerRow, BrokerRowProps } from './BrokerRow';
+import { useTranslation } from '@app/i18n/i18n';
+import { BrokerCR } from '@app/k8s/types';
+import {
+  TableColumn,
+  VirtualizedTable,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+type BrokersTableProps = Pick<
+  BrokerRowProps,
+  'onOpenModal' | 'onEditBroker'
+> & {
+  data: BrokerCR[];
+  unfilteredData: BrokerCR[];
+  loaded: boolean;
+  loadError: Error | null;
+};
+
+export const BrokersTable: FC<BrokersTableProps> = ({
+  data,
+  unfilteredData,
+  loaded,
+  loadError,
+  onOpenModal,
+  onEditBroker,
+}) => {
+  const { t } = useTranslation();
+
+  const columns: TableColumn<BrokerCR>[] = [
+    {
+      title: t('Name'),
+      id: 'name',
+    },
+    {
+      title: t('Ready'),
+      id: 'ready',
+    },
+    {
+      title: t('Conditions'),
+      id: 'conditions',
+    },
+    {
+      title: t('Size'),
+      id: 'Size',
+    },
+    {
+      title: t('Create'),
+      id: 'created',
+    },
+    {
+      title: '',
+      id: 'action',
+    },
+  ];
+
+  return (
+    <VirtualizedTable<BrokerCR>
+      data={data}
+      unfilteredData={unfilteredData}
+      loaded={loaded}
+      loadError={loadError}
+      columns={columns}
+      Row={({ obj, activeColumnIDs, rowData }) => (
+        <BrokerRow
+          obj={obj}
+          rowData={rowData}
+          activeColumnIDs={activeColumnIDs}
+          columns={columns}
+          onOpenModal={onOpenModal}
+          onEditBroker={onEditBroker}
+        />
+      )}
+    />
+  );
+};

--- a/src/k8s/types.ts
+++ b/src/k8s/types.ts
@@ -165,3 +165,12 @@ export type Ingress = K8sResourceCommon & {
     };
   };
 };
+
+export type ContainerStatus = {
+  name: string;
+  ready: boolean;
+  restartCount: number;
+  image?: string;
+  imageID?: string;
+  started?: boolean;
+};

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/ConfigurationPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/ConfigurationPage.tsx
@@ -14,7 +14,7 @@ export const enum ConfigType {
 
 type BrokerConfigProps = {
   brokerId: number;
-  target: any;
+  target: ConfigType;
   isPerBrokerConfig: boolean;
 };
 
@@ -32,15 +32,15 @@ export const ConfigurationPage: FC<BrokerConfigProps> = ({
     return <Text>{t('Per Broker Config is disabled for now.')}</Text>;
   }
 
-  const configType: ConfigType = target;
-
   if (target) {
     return (
       <Form isWidthLimited>
-        <ConfigTypeContext.Provider value={configType}>
-          {target === 'console' && <ConsoleConfigPage brokerId={brokerId} />}
-          {target === 'rbac' && <AccessControlPage />}
-          {['acceptors', 'connectors'].find((v) => v === target) && (
+        <ConfigTypeContext.Provider value={target}>
+          {target === ConfigType.console && (
+            <ConsoleConfigPage brokerId={brokerId} />
+          )}
+          {target === ConfigType.rbac && <AccessControlPage />}
+          {[ConfigType.acceptors, ConfigType.connectors].includes(target) && (
             <AcceptorsConfigPage brokerId={brokerId} />
           )}
         </ConfigTypeContext.Provider>

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -37,7 +37,10 @@ export const FormView: FC = () => {
     });
   };
 
-  const onChangeVersion = (value: '7.12' | '7.13') => {
+  const versions = ['7.12', '7.13'] as const;
+  type BrokerVersion = (typeof versions)[number];
+
+  const onChangeVersion = (value: BrokerVersion) => {
     dispatch({
       operation: ArtemisReducerGlobalOperations.setBrokerVersion,
       payload: value,
@@ -112,7 +115,9 @@ export const FormView: FC = () => {
                 </InputGroupText>
                 <FormSelect
                   value={formState.brokerVersion}
-                  onChange={(_event, value: any) => onChangeVersion(value)}
+                  onChange={(_event, value) =>
+                    onChangeVersion(value as BrokerVersion)
+                  }
                   aria-label="FormSelect Input"
                   isDisabled={formState?.cr?.spec?.restricted}
                 >


### PR DESCRIPTION
- Improved type safety in the code by refining TypeScript types and removing all `any` types.
- Enforced the ESLint `@typescript-eslint/no-explicit-any` rule to eliminate explicit 'any' type usage across the codebase.
-  Only a specific file at `./src/k8s/types.ts` was added to an overrides list due to dynamic data requirements.


fixes: [issue#134](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/134)