### PR TITLE
fix: Custom CSS causing yaml-editor buttons to disappear in default OpenShift UI

### DIFF
--- a/src/shared-components/YamlEditorView/YamlEditorView.css
+++ b/src/shared-components/YamlEditorView/YamlEditorView.css
@@ -1,10 +1,16 @@
-#save-changes {
+.broker-yaml-editor #save-changes {
   display: none;
 }
-#reload-object {
+.broker-yaml-editor #reload-object {
+  display: none;
+}
+.broker-yaml-editor #cancel {
   display: none;
 }
 
-#cancel {
-  display: none;
+.broker-yaml-editor {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
 }

--- a/src/shared-components/YamlEditorView/YamlEditorView.tsx
+++ b/src/shared-components/YamlEditorView/YamlEditorView.tsx
@@ -120,19 +120,21 @@ export const YamlEditorView: FC<YamlEditorViewPropTypes> = ({
         ))}
       </AlertGroup>
       <Suspense fallback={<Loading />}>
-        <ResourceYAMLEditor
-          initialResource={YAML.stringify(formState.cr, null, '  ')}
-          onSave={updateModel}
-          onChange={(newContent: string) => {
-            setCurrentYaml(newContent);
-            if (stringedFormState !== newContent) {
-              dispatch({
-                operation:
-                  ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges,
-              });
-            }
-          }}
-        />
+        <div className="broker-yaml-editor">
+          <ResourceYAMLEditor
+            initialResource={YAML.stringify(formState.cr, null, '  ')}
+            onSave={updateModel}
+            onChange={(newContent: string) => {
+              setCurrentYaml(newContent);
+              if (stringedFormState !== newContent) {
+                dispatch({
+                  operation:
+                    ArtemisReducerGlobalOperations.setYamlHasUnsavedChanges,
+                });
+              }
+            }}
+          />
+        </div>
       </Suspense>
     </>
   );


### PR DESCRIPTION
Scoped the CSS under `.broker-yaml-editor` to prevent it from hiding default OpenShift YAML editor buttons.

fixes: [issue#155](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/155)