### PR TITLE
fix: remove span wrapper to prevent button truncation on disabled state

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,7 +30,7 @@ rules:
   unused-imports/no-unused-imports-ts: 2
   no-console: 'error'
   no-alert: 'error'
-  no-explicit-any: 'error'
+  '@typescript-eslint/no-explicit-any': 'error'
 settings:
   react:
     version: detect
@@ -40,5 +40,4 @@ overrides:
       no-console: 'off'
   - files: ['./src/k8s/types.ts']
     rules:
-      no-explicit-any: 'off'
-  
+      '@typescript-eslint/no-explicit-any': 'off'

--- a/src/brokers/add-broker/AddBroker.component.tsx
+++ b/src/brokers/add-broker/AddBroker.component.tsx
@@ -186,11 +186,9 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
                 )}
                 trigger="mouseenter"
               >
-                <span className="pf-u-pt-sm pf-u-pl-sm pf-u-pb-sm">
-                  <Button variant={ButtonVariant.primary} isDisabled>
-                    {isUpdatingExisting ? t('Apply') : t('Create')}
-                  </Button>
-                </span>
+                <Button variant={ButtonVariant.primary} isDisabled>
+                  {isUpdatingExisting ? t('Apply') : t('Create')}
+                </Button>
               </Tooltip>
             ) : (
               <Button


### PR DESCRIPTION
- Removed span wrapper to fix disabled-state button truncation in the broker creation form when we clicked on the `RBAC Enabled` switch.
- also fixed eslint error by updating the correct `'@typescript-eslint/no-explicit-any'` rule

fixes: [issue[#162]](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/162)