### PR TITLE
Re-enabling type safety for the SPP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,41 +72,8 @@ jobs:
       - name: Extract translations
         run: yarn i18n && git diff --exit-code locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
 
-      - name: check strict mode for reducers/7.12
-        run: |
-          OUTPUT=$(yarn typecheck:7.12 2>&1 || true)
-          if echo "$OUTPUT" | grep -Eq "src/reducers/7.12/.*\.(ts|tsx).*error"; then
-            echo "$OUTPUT" | grep -E "src/reducers/7.12/.*\.(ts|tsx).*error"
-            exit 1
-          fi
-          echo "✓ No type errors in src/reducers/7.12/"
-
-      - name: check strict mode for reducers/7.13
-        run: |
-          OUTPUT=$(yarn typecheck:7.13 2>&1 || true)
-          if echo "$OUTPUT" | grep -Eq "src/reducers/7.13/.*\.(ts|tsx).*error"; then
-            echo "$OUTPUT" | grep -E "src/reducers/7.13/.*\.(ts|tsx).*error"
-            exit 1
-          fi
-          echo "✓ No type errors in src/reducers/7.13/"
-
-      - name: check strict mode for reducers
-        run: |
-          OUTPUT=$(yarn typecheck:global-reducers 2>&1 || true)
-          if echo "$OUTPUT" | grep -Eq "src/reducers/.*\.(ts|tsx).*error"; then
-            echo "$OUTPUT" | grep -E "src/reducers/.*\.(ts|tsx).*error"
-            exit 1
-          fi
-          echo "✓ No type errors in src/reducers/"
-          
-      - name: check strict mode for reducers/restricted
-        run: |
-          OUTPUT=$(yarn typecheck:restricted 2>&1 || true)
-          if echo "$OUTPUT" | grep -Eq "src/reducers/restricted/.*\.(ts|tsx).*error"; then
-            echo "$OUTPUT" | grep -E "src/reducers/restricted/.*\.(ts|tsx).*error"
-            exit 1
-          fi
-          echo "✓ No type errors in src/reducers/restricted/"
+      - name: Typecheck
+        run: yarn typecheck
 
       - name: Build project
         run: yarn run build

--- a/package.json
+++ b/package.json
@@ -13,10 +13,7 @@
   "scripts": {
     "build": "yarn clean && NODE_ENV=production yarn webpack",
     "build-dev": "yarn clean && yarn webpack",
-    "typecheck:7.12": "tsc -p src/reducers/7.12/tsconfig.json --noEmit",
-    "typecheck:7.13": "tsc -p src/reducers/7.13/tsconfig.json --noEmit",
-    "typecheck:global-reducers": "tsc -p src/reducers/tsconfig.json --noEmit",
-    "typecheck:restricted": "tsc -p src/reducers/restricted/tsconfig.json --noEmit",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "format:all": "prettier --config ./.prettierrc.yml --write './src/**/*'",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",

--- a/src/brokers/add-broker/AddBroker.component.test.tsx
+++ b/src/brokers/add-broker/AddBroker.component.test.tsx
@@ -22,12 +22,18 @@ const SimplifiedCreaterBrokerPage: FC = () => {
   const onCancel = () => {
     return 0;
   };
+  const reloadExisting = jest.fn();
+
   const initialValues = newArtemisCR('default');
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
   return (
     <BrokerCreationFormState.Provider value={brokerModel}>
       <BrokerCreationFormDispatch.Provider value={dispatch}>
-        <AddBroker onSubmit={onSubmit} onCancel={onCancel} />
+        <AddBroker
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+          reloadExisting={reloadExisting}
+        />
       </BrokerCreationFormDispatch.Provider>
     </BrokerCreationFormState.Provider>
   );
@@ -40,9 +46,8 @@ const SimplifiedUpdateBrokerPage: FC = () => {
   const onCancel = () => {
     return 0;
   };
-  const reloadExisting = () => {
-    return 0;
-  };
+  const reloadExisting = jest.fn();
+
   const initialValues = newArtemisCR('default');
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
   return (

--- a/src/brokers/add-broker/AddBroker.component.tsx
+++ b/src/brokers/add-broker/AddBroker.component.tsx
@@ -43,7 +43,7 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
   const formValues = useContext(BrokerCreationFormState);
   const dispatch = useContext(BrokerCreationFormDispatch);
 
-  const { editorType } = formValues;
+  const { editorType = EditorType.BROKER } = formValues;
 
   const [userWantsToQuit, setUserWantsToQuit] = useState<boolean>(false);
   const [userWantsToReload, setUserWantsToReload] = useState<boolean>(false);
@@ -109,7 +109,7 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
   }
 
   const { t } = useTranslation();
-  const namespace = formValues.cr.metadata.namespace;
+  const namespace = formValues.cr?.metadata?.namespace;
   const [canCreateBroker, loadingAccessReview] = useAccessReview({
     group: AMQBrokerModel.apiGroup,
     resource: AMQBrokerModel.plural,
@@ -220,7 +220,7 @@ export const AddBroker: FC<AddBrokerPropTypes> = ({
                   if (formValues.hasChanges) {
                     setUserWantsToReload(true);
                   } else {
-                    reloadExisting();
+                    reloadExisting?.();
                   }
                 }}
               >

--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -1,6 +1,7 @@
 import { FC, useReducer, useState } from 'react';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, AlertVariant } from '@patternfly/react-core';
+import { useTranslation } from '@app/i18n/i18n';
 import { AddBroker } from './AddBroker.component';
 import { AMQBrokerModel } from '@app/k8s/models';
 import { BrokerCR } from '@app/k8s/types';
@@ -11,6 +12,7 @@ import {
   newArtemisCR,
 } from '@app/reducers/reducer';
 import { ArtemisReducerOperations712 } from '@app/reducers/7.12/reducer';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 import { FormState712 } from '@app/reducers/7.12/import-types';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useGetIngressDomain } from '@app/k8s/customHooks';
@@ -20,13 +22,23 @@ export interface AddBrokerProps {
 }
 
 export const AddBrokerPage: FC = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { ns: namespace } = useParams<{ ns?: string }>();
-
-  const initialValues = newArtemisCR(namespace);
+  const initialValues = newArtemisCR(namespace ?? '');
 
   //states
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
+  const [_hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
+  const [alert, setAlert] = useState('');
+  const [prevNamespace, setPrevNamespace] = useState(namespace);
+  const { clusterDomain, isLoading } = useGetIngressDomain();
+  const [isDomainSet, setIsDomainSet] = useState(false);
+
+  // Early return after all hooks
+  if (!namespace) {
+    return <GenericError message={t('Namespace is required.')} />;
+  }
 
   const params = new URLSearchParams(location.search);
   const returnUrl = params.get('returnUrl');
@@ -38,9 +50,6 @@ export const AddBrokerPage: FC = () => {
       navigate(-1);
     }
   };
-
-  const [_hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
-  const [alert, setAlert] = useState('');
 
   const k8sCreateBroker = (content: BrokerCR) => {
     k8sCreate({ model: AMQBrokerModel, data: content })
@@ -59,7 +68,6 @@ export const AddBrokerPage: FC = () => {
       });
   };
 
-  const [prevNamespace, setPrevNamespace] = useState(namespace);
   if (prevNamespace !== namespace) {
     dispatch({
       operation: ArtemisReducerOperations712.setNamespace,
@@ -68,8 +76,6 @@ export const AddBrokerPage: FC = () => {
     setPrevNamespace(namespace);
   }
 
-  const { clusterDomain, isLoading } = useGetIngressDomain();
-  const [isDomainSet, setIsDomainSet] = useState(false);
   if (!isLoading && !isDomainSet) {
     dispatch({
       operation: ArtemisReducerOperations712.setIngressDomain,
@@ -80,6 +86,9 @@ export const AddBrokerPage: FC = () => {
     });
     setIsDomainSet(true);
   }
+
+  const { cr } = brokerModel;
+  if (!cr) return <GenericError />;
 
   return (
     <BrokerCreationFormState.Provider value={brokerModel}>
@@ -94,7 +103,7 @@ export const AddBrokerPage: FC = () => {
           />
         )}
         <AddBroker
-          onSubmit={() => k8sCreateBroker(brokerModel.cr)}
+          onSubmit={() => k8sCreateBroker(cr)}
           onCancel={handleRedirect}
         />
       </BrokerCreationFormDispatch.Provider>

--- a/src/brokers/add-broker/components/EditorToggle/EditorToggle.tsx
+++ b/src/brokers/add-broker/components/EditorToggle/EditorToggle.tsx
@@ -5,7 +5,7 @@ import { EditorType } from '@app/reducers/reducer';
 
 type EditorToggleProps = {
   value: EditorType;
-  onChange?: (editorType: EditorType) => void;
+  onChange: (editorType: EditorType) => void;
   isDisabled?: boolean;
 };
 
@@ -19,7 +19,7 @@ export const EditorToggle: React.FC<EditorToggleProps> = ({
     _checked: boolean,
     event: React.FormEvent<HTMLInputElement>,
   ) => {
-    onChange(event?.currentTarget?.value as EditorType);
+    onChange(event.currentTarget.value as EditorType);
   };
   return (
     <div className="pf-u-mx-md pf-u-my-sm">

--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -15,6 +15,7 @@ import {
 import { YamlContainer } from './components/yaml/Yaml.container';
 import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
 import { Loading } from '@app/shared-components/Loading/Loading';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 type AuthenticatedPageContentPropType = {
   brokerCr: BrokerCR;
@@ -65,9 +66,18 @@ const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
 };
 
 export const BrokerDetailsPage: FC = () => {
+  const { t } = useTranslation();
   const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
+  const { brokerCr, isLoading, error } = useGetBrokerCR(
+    name ?? '',
+    namespace ?? '',
+  );
 
-  const { brokerCr, isLoading, error } = useGetBrokerCR(name, namespace);
+  if (!name || !namespace) {
+    return (
+      <GenericError message={t('Namespace and broker name are required.')} />
+    );
+  }
 
   if (isLoading) {
     return <Loading />;
@@ -81,8 +91,8 @@ export const BrokerDetailsPage: FC = () => {
     <>
       <AuthenticatedPageContent
         brokerCr={brokerCr}
-        name={name}
-        namespace={namespace}
+        name={name || ''}
+        namespace={namespace || ''}
       />
     </>
   );

--- a/src/brokers/broker-details/components/Overview/ConnectivityTester.tsx
+++ b/src/brokers/broker-details/components/Overview/ConnectivityTester.tsx
@@ -195,7 +195,11 @@ const deleteResource = async (
       json: deleteOptions,
     });
   } catch (error) {
-    const statusCode = error?.code || error?.response?.status;
+    const err = error as {
+      code?: number;
+      response?: { status?: number };
+    } | null;
+    const statusCode = err?.code || err?.response?.status;
     if (statusCode !== 404) {
       throw error;
     }
@@ -204,8 +208,8 @@ const deleteResource = async (
 
 export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
   const { t } = useTranslation();
-  const brokerName = cr.metadata.name;
-  const namespace = cr.metadata.namespace;
+  const brokerName = cr.metadata?.name;
+  const namespace = cr.metadata?.namespace;
   const jaasSecretName = `${brokerName}-jaas-config-bp`;
   const producerJobName = `${brokerName}-producer`;
   const consumerJobName = `${brokerName}-consumer`;
@@ -301,23 +305,30 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
   });
 
   const issuerOptions = useMemo<IssuerOption[]>(() => {
-    const issuerEntries =
-      issuers?.map((issuer) => ({
-        value: `Issuer:${issuer.metadata.name}`,
-        name: issuer.metadata.name,
-        label: `${issuer.metadata.name} (Issuer)`,
-        kind: 'Issuer' as const,
-      })) || [];
-    const clusterIssuerEntries =
-      clusterIssuers?.map((issuer) => ({
-        value: `ClusterIssuer:${issuer.metadata.name}`,
-        name: issuer.metadata.name,
-        label: `${issuer.metadata.name} (ClusterIssuer)`,
-        kind: 'ClusterIssuer' as const,
-      })) || [];
-    return [...issuerEntries, ...clusterIssuerEntries].sort((a, b) =>
-      a.label.localeCompare(b.label),
-    );
+    const issuerEntries: IssuerOption[] = [];
+    for (const issuer of issuers || []) {
+      const name = issuer.metadata?.name;
+      if (name) {
+        issuerEntries.push({
+          value: `Issuer:${name}`,
+          name,
+          label: `${name} (Issuer)`,
+          kind: 'Issuer',
+        });
+      }
+    }
+    for (const issuer of clusterIssuers || []) {
+      const name = issuer.metadata?.name;
+      if (name) {
+        issuerEntries.push({
+          value: `ClusterIssuer:${name}`,
+          name,
+          label: `${name} (ClusterIssuer)`,
+          kind: 'ClusterIssuer',
+        });
+      }
+    }
+    return issuerEntries.sort((a, b) => a.label.localeCompare(b.label));
   }, [clusterIssuers, issuers]);
 
   const [selectedIssuer, setSelectedIssuer] = useState<
@@ -386,6 +397,15 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
     : '';
 
   const handleCreateClientCert = async () => {
+    if (!namespace) {
+      setClientCertStatus({
+        status: 'error',
+        message: t(
+          'Namespace is not available. Cannot create client certificate.',
+        ),
+      });
+      return;
+    }
     if (!selectedIssuer) {
       setClientCertStatus({
         status: 'error',
@@ -434,9 +454,10 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
         message: t('messaging-client-cert certificate created.'),
       });
     } catch (error) {
+      const err = error as { message?: string } | null;
       setClientCertStatus({
         status: 'error',
-        message: error?.message || t('Failed to create messaging-client-cert.'),
+        message: err?.message || t('Failed to create messaging-client-cert.'),
       });
     }
 
@@ -466,9 +487,10 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
         message: t('cert-pemcfg secret created.'),
       });
     } catch (error) {
+      const err = error as { message?: string } | null;
       setPemcfgStatus({
         status: 'error',
-        message: error?.message || t('Failed to create cert-pemcfg secret.'),
+        message: err?.message || t('Failed to create cert-pemcfg secret.'),
       });
     }
   };
@@ -529,6 +551,13 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
     command: string,
     setStatus: (s: ActionState) => void,
   ) => {
+    if (!namespace) {
+      setStatus({
+        status: 'error',
+        message: t('Namespace is not available. Cannot run job.'),
+      });
+      return;
+    }
     if (!brokerVersion) {
       setStatus({
         status: 'error',
@@ -550,10 +579,11 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
         message: t('{{job}} job started.', { job: name }),
       });
     } catch (error) {
+      const err = error as { message?: string } | null;
       setStatus({
         status: 'error',
         message:
-          error?.message || t('Failed to start {{job}} job.', { job: name }),
+          err?.message || t('Failed to start {{job}} job.', { job: name }),
       });
     }
   };
@@ -586,6 +616,13 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
   };
 
   const handleCleanup = async () => {
+    if (!namespace) {
+      setCleanupStatus({
+        status: 'error',
+        message: t('Namespace is not available. Cannot clean up resources.'),
+      });
+      return;
+    }
     setCleanupStatus({ status: 'working' });
     try {
       await deleteResource(JobModel, producerJobName, namespace, {
@@ -606,9 +643,10 @@ export const ConnectivityTester: FC<ConnectivityTesterProps> = ({ cr }) => {
         message: t('Connectivity test resources deleted.'),
       });
     } catch (error) {
+      const err = error as { message?: string } | null;
       setCleanupStatus({
         status: 'error',
-        message: error?.message || t('Failed to clean up resources.'),
+        message: err?.message || t('Failed to clean up resources.'),
       });
     }
   };

--- a/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerCPUUsageMetrics/CardBrokerCPUUsageMetrics.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerCPUUsageMetrics/CardBrokerCPUUsageMetrics.container.tsx
@@ -6,21 +6,20 @@ import { MetricsPolling } from '../MetricsPolling/MetricsPolling';
 import { useTranslation } from '@app/i18n/i18n';
 import { CardQueryBrowser } from '../CardQueryBrowser/CardQueryBrowser';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import { MetricsState } from '../../utils/types';
+import { MetricsState, AxisDomain, getDefaultXDomain } from '../../utils/types';
 import { MetricsErrorBoundary } from '../../MetricsErrorBoundary';
 
 type CardBrokerCPUUsageMetricsContainerProps = {
   state: MetricsState;
 };
 
-type AxisDomain = [number, number];
-
 export const CardBrokerCPUUsageMetricsContainer: FC<
   CardBrokerCPUUsageMetricsContainerProps
 > = ({ state }) => {
   const { t } = useTranslation();
+  const span = parsePrometheusDuration(state.span);
 
-  const [xDomain] = useState<AxisDomain>();
+  const [xDomain] = useState<AxisDomain>(() => getDefaultXDomain(span));
   // State to store the results from each MetricsPolling component.
   // The key is the index of the poller.
   const [results, setResults] = useState<{

--- a/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerMemoryUsageMetrics/CardBrokerMemoryUsageMetrics.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerMemoryUsageMetrics/CardBrokerMemoryUsageMetrics.container.tsx
@@ -2,28 +2,32 @@ import { FC, useState, useMemo, useCallback } from 'react';
 import { parsePrometheusDuration } from '../../../Metrics/utils/prometheus';
 import { getMaxSamplesForSpan } from '../../utils/format';
 import { humanizeBinaryBytes } from '../../utils/units';
-import { ByteDataTypes, GraphSeries } from '../../utils/types';
+import {
+  ByteDataTypes,
+  GraphSeries,
+  MetricsState,
+  AxisDomain,
+  getDefaultXDomain,
+} from '../../utils/types';
 import { processFrame } from '../../utils/data-utils';
 import { memoryUsageQuery } from '../../utils/queries';
 import { MetricsPolling } from '../MetricsPolling/MetricsPolling';
 import { useTranslation } from '@app/i18n/i18n';
 import { CardQueryBrowser } from '../CardQueryBrowser/CardQueryBrowser';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import { MetricsState } from '../../utils/types';
 import { MetricsErrorBoundary } from '../../MetricsErrorBoundary';
 
 type CardBrokerMemoryUsageMetricsContainerProps = {
   state: MetricsState;
 };
 
-type AxisDomain = [number, number];
-
 export const CardBrokerMemoryUsageMetricsContainer: FC<
   CardBrokerMemoryUsageMetricsContainerProps
 > = ({ state }) => {
   const { t } = useTranslation();
+  const span = parsePrometheusDuration(state.span);
 
-  const [xDomain] = useState<AxisDomain>();
+  const [xDomain] = useState<AxisDomain>(() => getDefaultXDomain(span));
   // State to store the results from each MetricsPolling component.
   // The key is the index of the poller.
   const [results, setResults] = useState<{
@@ -78,7 +82,7 @@ export const CardBrokerMemoryUsageMetricsContainer: FC<
     return { metricsResult, loaded, errorObject };
   }, [results, queries]);
 
-  const samples = getMaxSamplesForSpan(parsePrometheusDuration(state.span));
+  const samples = getMaxSamplesForSpan(span);
 
   // Define this once for all queries so that they have exactly the same time range and X values
   const endTime = xDomain?.[1];
@@ -102,7 +106,7 @@ export const CardBrokerMemoryUsageMetricsContainer: FC<
           query={query}
           index={i}
           namespace={state.namespace}
-          span={parsePrometheusDuration(state.span)}
+          span={span}
           samples={samples}
           endTime={endTime}
           delay={parsePrometheusDuration(state.pollTime)}
@@ -114,7 +118,7 @@ export const CardBrokerMemoryUsageMetricsContainer: FC<
           isInitialLoading={false}
           backendUnavailable={false}
           allMetricsSeries={metricsResult}
-          span={parsePrometheusDuration(state.span)}
+          span={span}
           isLoading={!loaded}
           fixedXDomain={xDomain}
           samples={samples}

--- a/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerPendingMessagesMetrics/CardBrokerPendingMessagesMetrics.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerPendingMessagesMetrics/CardBrokerPendingMessagesMetrics.container.tsx
@@ -6,21 +6,20 @@ import { MetricsPolling } from '../MetricsPolling/MetricsPolling';
 import { useTranslation } from '@app/i18n/i18n';
 import { CardQueryBrowser } from '../CardQueryBrowser/CardQueryBrowser';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import { MetricsState } from '../../utils/types';
+import { MetricsState, AxisDomain, getDefaultXDomain } from '../../utils/types';
 import { MetricsErrorBoundary } from '../../MetricsErrorBoundary';
 
 type CardBrokerPendingMessagesMetricsContainerProps = {
   state: MetricsState;
 };
 
-type AxisDomain = [number, number];
-
 export const CardBrokerPendingMessagesMetricsContainer: FC<
   CardBrokerPendingMessagesMetricsContainerProps
 > = ({ state }) => {
   const { t } = useTranslation();
+  const span = parsePrometheusDuration(state.span);
 
-  const [xDomain] = useState<AxisDomain>();
+  const [xDomain] = useState<AxisDomain>(() => getDefaultXDomain(span));
   const [results, setResults] = useState<{
     [key: number]: {
       result: PrometheusResponse | null;

--- a/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerThroughputMetrics/CardBrokerThroughputMetrics.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerThroughputMetrics/CardBrokerThroughputMetrics.container.tsx
@@ -6,21 +6,20 @@ import { MetricsPolling } from '../MetricsPolling/MetricsPolling';
 import { useTranslation } from '@app/i18n/i18n';
 import { CardQueryBrowser } from '../CardQueryBrowser/CardQueryBrowser';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import { MetricsState } from '../../utils/types';
+import { MetricsState, AxisDomain, getDefaultXDomain } from '../../utils/types';
 import { MetricsErrorBoundary } from '../../MetricsErrorBoundary';
 
 type CardBrokerThroughputMetricsContainerProps = {
   state: MetricsState;
 };
 
-type AxisDomain = [number, number];
-
 export const CardBrokerThroughputMetricsContainer: FC<
   CardBrokerThroughputMetricsContainerProps
 > = ({ state }) => {
   const { t } = useTranslation();
+  const span = parsePrometheusDuration(state.span);
 
-  const [xDomain] = useState<AxisDomain>();
+  const [xDomain] = useState<AxisDomain>(() => getDefaultXDomain(span));
   const [results, setResults] = useState<{
     [key: number]: {
       result: PrometheusResponse | null;

--- a/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerTotalProducedMetrics/CardBrokerTotalProducedMetrics.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/CardBrokerTotalProducedMetrics/CardBrokerTotalProducedMetrics.container.tsx
@@ -6,21 +6,20 @@ import { MetricsPolling } from '../MetricsPolling/MetricsPolling';
 import { useTranslation } from '@app/i18n/i18n';
 import { CardQueryBrowser } from '../CardQueryBrowser/CardQueryBrowser';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import { MetricsState } from '../../utils/types';
+import { MetricsState, AxisDomain, getDefaultXDomain } from '../../utils/types';
 import { MetricsErrorBoundary } from '../../MetricsErrorBoundary';
 
 type CardBrokerTotalProducedMetricsContainerProps = {
   state: MetricsState;
 };
 
-type AxisDomain = [number, number];
-
 export const CardBrokerTotalProducedMetricsContainer: FC<
   CardBrokerTotalProducedMetricsContainerProps
 > = ({ state }) => {
   const { t } = useTranslation();
+  const span = parsePrometheusDuration(state.span);
 
-  const [xDomain] = useState<AxisDomain>();
+  const [xDomain] = useState<AxisDomain>(() => getDefaultXDomain(span));
   const [results, setResults] = useState<{
     [key: number]: {
       result: PrometheusResponse | null;

--- a/src/brokers/broker-details/components/Overview/Metrics/components/ChartCPUUsage/ChartCPUUsage.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/ChartCPUUsage/ChartCPUUsage.tsx
@@ -29,11 +29,13 @@ import {
   AxisDomain,
   FormatSeriesTitle,
   GraphSeries,
-  GraphDataPoint,
   Series,
+  isGraphPoint,
+  findMin,
+  findMax,
 } from '../../utils/types';
 
-const colors = chartTheme.line.colorScale;
+const colors = chartTheme.line?.colorScale;
 
 export type ChartCPUUsageProps = {
   allMetricsSeries: PrometheusResponse[];
@@ -82,36 +84,27 @@ export const ChartCPUUsage: FC<ChartCPUUsageProps> = ({
   // }, [allMetricsSeries, span, fixedXDomain]);
 
   const newGraphData = newResult.map((result: PrometheusResult[]) => {
-    return result.map(({ metric, values }): Series => {
+    return result.map(({ metric, values = [] }): Series => {
       return [metric, formatSeriesValues(values, samples, span)];
     });
   });
 
   newGraphData.forEach((series, i) => {
-    series.forEach(([metric, values]) => {
+    series.forEach(([metric, values = []]) => {
       data.push(values);
-      if (formatSeriesTitle) {
+      if (formatSeriesTitle && metric) {
         const name = formatSeriesTitle(metric, i);
         legendData.push({ name });
         tooltipSeriesNames.push(name);
-      } else {
+      } else if (metric) {
         tooltipSeriesLabels.push(metric);
       }
     });
   });
 
   // Set a reasonable Y-axis range based on the min and max values in the data
-  const findMin = (series: GraphSeries): GraphDataPoint | undefined => {
-    if (!series.length) return undefined;
-    return series.reduce((min, point) => (point.y < min.y ? point : min));
-  };
-  const findMax = (series: GraphSeries): GraphDataPoint => {
-    if (!series.length) return undefined;
-    return series.reduce((max, point) => (point.y > max.y ? point : max));
-  };
-
-  const minPoints = data.map(findMin).filter(Boolean);
-  const maxPoints = data.map(findMax).filter(Boolean);
+  const minPoints = data.map(findMin).filter(isGraphPoint);
+  const maxPoints = data.map(findMax).filter(isGraphPoint);
 
   let minY: number = findMin(minPoints)?.y ?? 0;
   let maxY: number = findMax(maxPoints)?.y ?? 0;
@@ -183,7 +176,11 @@ export const ChartCPUUsage: FC<ChartCPUUsageProps> = ({
                       return null;
                     }
 
-                    const color = colors[index % colors.length];
+                    const color =
+                      colors && colors.length > 0
+                        ? colors[index % colors.length]
+                        : undefined;
+
                     const style = {
                       data: { stroke: color },
                       labels: {

--- a/src/brokers/broker-details/components/Overview/Metrics/components/ChartMemoryUsage/ChartMemoryUsage.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/ChartMemoryUsage/ChartMemoryUsage.tsx
@@ -27,12 +27,14 @@ import {
   AxisDomain,
   FormatSeriesTitle,
   GraphSeries,
-  GraphDataPoint,
   Series,
+  isGraphPoint,
+  findMin,
+  findMax,
 } from '../../utils/types';
 import { processFrame } from '../../utils/data-utils';
 
-const colors = chartTheme.line.colorScale;
+const colors = chartTheme.line?.colorScale;
 
 export type ChartMemoryUsageProps = {
   allMetricsSeries: PrometheusResponse[];
@@ -72,19 +74,19 @@ export const ChartMemoryUsage: FC<ChartMemoryUsageProps> = ({
   // }, [allMetricsSeries, span, fixedXDomain]);
 
   const newGraphData = newResult.map((result: PrometheusResult[]) => {
-    return result.map(({ metric, values }): Series => {
+    return result.map(({ metric, values = [] }): Series => {
       return [metric, formatSeriesValues(values, samples, span)];
     });
   });
 
   newGraphData.forEach((series, i) => {
-    series.forEach(([metric, values]) => {
+    series.forEach(([metric, values = []]) => {
       data.push(values);
-      if (formatSeriesTitle) {
+      if (formatSeriesTitle && metric) {
         const name = formatSeriesTitle(metric, i);
         legendData.push({ name });
         tooltipSeriesNames.push(name);
-      } else {
+      } else if (metric) {
         tooltipSeriesLabels.push(metric);
       }
     });
@@ -109,17 +111,8 @@ export const ChartMemoryUsage: FC<ChartMemoryUsageProps> = ({
   );
 
   // Set a reasonable Y-axis range based on the min and max values in the data
-  const findMin = (series: GraphSeries): GraphDataPoint | undefined => {
-    if (!series.length) return undefined;
-    return series.reduce((min, point) => (point.y < min.y ? point : min));
-  };
-  const findMax = (series: GraphSeries): GraphDataPoint => {
-    if (!series.length) return undefined;
-    return series.reduce((max, point) => (point.y > max.y ? point : max));
-  };
-
-  const minPoints = data.map(findMin).filter(Boolean);
-  const maxPoints = data.map(findMax).filter(Boolean);
+  const minPoints = data.map(findMin).filter(isGraphPoint);
+  const maxPoints = data.map(findMax).filter(isGraphPoint);
 
   let minY: number = findMin(minPoints)?.y ?? 0;
   let maxY: number = findMax(maxPoints)?.y ?? 0;
@@ -190,7 +183,11 @@ export const ChartMemoryUsage: FC<ChartMemoryUsageProps> = ({
                       return null;
                     }
 
-                    const color = colors[index % colors.length];
+                    const color =
+                      colors && colors.length > 0
+                        ? colors[index % colors.length]
+                        : undefined;
+
                     const style = {
                       data: { stroke: color },
                       labels: {

--- a/src/brokers/broker-details/components/Overview/Metrics/components/DropDownWithToggle/DropdownWithToggle.test.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/DropDownWithToggle/DropdownWithToggle.test.tsx
@@ -55,6 +55,6 @@ describe('PreConfirmDeleteModal', () => {
       fireEvent.click(selectDropdownItem);
     });
 
-    expect(onSelectOption).toHaveBeenCalledWith('15m', undefined);
+    expect(onSelectOption).toHaveBeenCalledWith('15m', '');
   });
 });

--- a/src/brokers/broker-details/components/Overview/Metrics/components/DropDownWithToggle/DropdownWithToggle.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/DropDownWithToggle/DropdownWithToggle.tsx
@@ -42,11 +42,13 @@ export const DropdownWithToggle = <T,>({
   };
 
   const onSelect: DropdownProps['onSelect'] = (e) => {
-    if (e && e.currentTarget.textContent) {
-      const value: string = e.currentTarget.textContent;
-      const filteredOption = items?.filter((item) => item.label === value)[0];
-      if (onSelectOption && filteredOption) {
-        onSelectOption(filteredOption.value, name);
+    if (e?.currentTarget?.textContent) {
+      const selectedValue: string = e.currentTarget.textContent;
+      const filteredOption = items?.filter(
+        (item) => item.label === selectedValue,
+      )[0];
+      if (onSelectOption && filteredOption?.value !== undefined) {
+        onSelectOption(filteredOption.value, name ?? '');
       }
       setIsOpen((isOpen) => !isOpen);
     }

--- a/src/brokers/broker-details/components/Overview/Metrics/components/MetricsLayout/MetricsLayout.test.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/MetricsLayout/MetricsLayout.test.tsx
@@ -46,18 +46,4 @@ describe('MetricsLayout', () => {
     await waitForI18n(comp);
     expect(comp.getByText('Mock CPU Usage')).toBeInTheDocument();
   });
-
-  it('should not renders MetricsMemoryUsage and MetricsCPUUsage when metricsType is Empty', async () => {
-    const comp = render(
-      <MetricsLayout
-        metricsMemoryUsage={mockMetricsMemoryUsage}
-        metricsCPUUsage={mockMetricsCPUUsage}
-        metricsActions={mockMetricsActions}
-        metricsType={null}
-      />,
-    );
-    await waitForI18n(comp);
-    expect(comp.queryByText('Mock Memory Usage')).toBeNull();
-    expect(comp.queryByText('Mock CPU Usage')).toBeNull();
-  });
 });

--- a/src/brokers/broker-details/components/Overview/Metrics/components/MetricsPolling/MetricsPolling.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/MetricsPolling/MetricsPolling.tsx
@@ -60,7 +60,7 @@ export const MetricsPolling: React.FC<MetricsPollingProps> = ({
   });
 
   useEffect(() => {
-    onResult(index, result, loaded, loadError);
+    onResult(index, result ?? null, loaded, loadError);
   }, [index, result, loaded, loadError, onResult]);
 
   return null;

--- a/src/brokers/broker-details/components/Overview/Metrics/components/QueryBrowser/QueryBrowser.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/components/QueryBrowser/QueryBrowser.tsx
@@ -25,12 +25,14 @@ import {
   AxisDomain,
   FormatSeriesTitle,
   GraphSeries,
-  GraphDataPoint,
   Series,
+  isGraphPoint,
+  findMin,
+  findMax,
 } from '../../utils/types';
 import { DataPoint } from '../../utils/data-utils';
 
-const colors = chartTheme.line.colorScale;
+const colors = chartTheme.line?.colorScale;
 
 export type QueryBrowserProps = {
   allMetricsSeries: PrometheusResponse[];
@@ -83,19 +85,19 @@ export const QueryBrowser: FC<QueryBrowserProps> = ({
   // }, [allMetricsSeries, span, fixedXDomain]);
 
   const newGraphData = newResult.map((result: PrometheusResult[]) => {
-    return result.map(({ metric, values }): Series => {
+    return result.map(({ metric, values = [] }): Series => {
       return [metric, formatSeriesValues(values, samples, span)];
     });
   });
 
   newGraphData.forEach((series, i) => {
-    series.forEach(([metric, values]) => {
+    series.forEach(([metric, values = []]) => {
       data.push(values);
-      if (formatSeriesTitle) {
+      if (formatSeriesTitle && metric) {
         const name = formatSeriesTitle(metric, i);
         legendData.push({ name });
         tooltipSeriesNames.push(name);
-      } else {
+      } else if (metric) {
         tooltipSeriesLabels.push(metric);
       }
     });
@@ -110,17 +112,8 @@ export const QueryBrowser: FC<QueryBrowserProps> = ({
   );
 
   // Set a reasonable Y-axis range based on the min and max values in the data
-  const findMin = (series: GraphSeries): GraphDataPoint | undefined => {
-    if (!series.length) return undefined;
-    return series.reduce((min, point) => (point.y < min.y ? point : min));
-  };
-  const findMax = (series: GraphSeries): GraphDataPoint | undefined => {
-    if (!series.length) return undefined;
-    return series.reduce((max, point) => (point.y > max.y ? point : max));
-  };
-
-  const minPoints = data.map(findMin).filter(Boolean);
-  const maxPoints = data.map(findMax).filter(Boolean);
+  const minPoints = data.map(findMin).filter(isGraphPoint);
+  const maxPoints = data.map(findMax).filter(isGraphPoint);
 
   let minY: number = findMin(minPoints)?.y ?? 0;
   let maxY: number = findMax(maxPoints)?.y ?? 0;
@@ -135,7 +128,8 @@ export const QueryBrowser: FC<QueryBrowserProps> = ({
 
   domain.y = [minY, maxY];
 
-  const metricsDataPoints = metricsType === 'memory' ? processedData : data;
+  const metricsDataPoints =
+    metricsType === 'memory' ? processedData ?? [] : data ?? [];
 
   return (
     <div ref={containerRef} style={{ height: '500px' }}>
@@ -206,7 +200,11 @@ export const QueryBrowser: FC<QueryBrowserProps> = ({
                       return null;
                     }
 
-                    const color = colors[index % colors.length];
+                    const color =
+                      colors && colors.length > 0
+                        ? colors[index % colors.length]
+                        : undefined;
+
                     const style = {
                       data: { stroke: color },
                       labels: {

--- a/src/brokers/broker-details/components/Overview/Metrics/hooks/useChartWidth.tsx
+++ b/src/brokers/broker-details/components/Overview/Metrics/hooks/useChartWidth.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
 export const useChartWidth = () => {
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement | null>(null);
   const [width, setWidth] = useState<number>();
 
-  const setRef = useCallback((e: HTMLDivElement) => {
+  const setRef = useCallback((e: HTMLDivElement | null) => {
     const newWidth = e?.clientWidth;
     newWidth &&
       ref.current?.clientWidth !== newWidth &&

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/data-utils.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/data-utils.ts
@@ -29,10 +29,13 @@ const bestUnit = (
 ) => {
   const flattenDataPoints = dataPoints.reduce(
     (acc, arr) => acc.concat(arr),
-    [],
+    [] as DataPoint[],
   );
 
   const bestLevel = flattenDataPoints.reduce((maxUnit, point) => {
+    if (point.y === undefined) {
+      return maxUnit;
+    }
     const index = Math.floor(log(type?.divisor ?? 1024, point.y));
     const unitIndex =
       index >= type.units.length ? type.units.length - 1 : index;
@@ -47,14 +50,16 @@ export const processFrame = (
   typeName: string,
 ): ProcessFrameResult => {
   const type = getType(typeName);
-  let unit = null;
+  let unit = type.units[0];
   if (dataPoints && dataPoints[0]) {
     // Get the appropriate unit and convert the dataset to that level
     unit = bestUnit(dataPoints, type);
     const frameLevel = type.units.indexOf(unit);
     dataPoints.forEach((arr) =>
       arr.forEach((point) => {
-        point.y /= type.divisor ** frameLevel;
+        if (typeof point.y === 'number') {
+          point.y /= type.divisor ** frameLevel;
+        }
       }),
     );
   }

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/format.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/format.ts
@@ -81,7 +81,7 @@ export const formatSeriesValues = (
     const y = Number(v[1]);
     return {
       x: new Date(v[0] * 1000),
-      y: Number.isNaN(y) ? null : y,
+      y: Number.isNaN(y) ? 0 : y,
     };
   });
 
@@ -93,7 +93,7 @@ export const formatSeriesValues = (
   for (let t = start, i = 0; t < end; t += step, i++) {
     const x = new Date(t);
     if (newValues[i]?.x > x) {
-      newValues.splice(i, 0, { x, y: null });
+      newValues.splice(i, 0, { x, y: NaN });
     }
   }
 

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/prometheus.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/prometheus.ts
@@ -46,11 +46,11 @@ export const parsePrometheusDuration = (duration: string): number => {
       .trim()
       .split(/\s+/)
       .map((p) => p.match(/^(\d+)([wdhms])$/));
-    return parts.reduce(
-      (sum, p: RegExpMatchArray | null) =>
-        sum + parseInt(p[1], 10) * units[p[2]],
-      0,
-    );
+
+    return parts.reduce((sum, p: RegExpMatchArray | null) => {
+      if (!p) return sum;
+      return sum + parseInt(p[1], 10) * units[p[2]];
+    }, 0);
   } catch (ignored) {
     // Invalid duration format
     return 0;

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/types.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/types.ts
@@ -32,6 +32,25 @@ export type FormatSeriesTitle = (
 ) => string;
 export type GraphSeries = GraphDataPoint[];
 export type AxisDomain = [number, number];
+
+export const isGraphPoint = (
+  point: GraphDataPoint | undefined,
+): point is GraphDataPoint => point !== undefined;
+
+export const findMin = (series: GraphSeries): GraphDataPoint | undefined => {
+  if (!series.length) return undefined;
+  return series.reduce((min, point) => (point.y < min.y ? point : min));
+};
+
+export const findMax = (series: GraphSeries): GraphDataPoint | undefined => {
+  if (!series.length) return undefined;
+  return series.reduce((max, point) => (point.y > max.y ? point : max));
+};
+
+export const getDefaultXDomain = (span: number): AxisDomain => {
+  const endTime = Date.now();
+  return [endTime - span, endTime];
+};
 export type Series = [PrometheusLabels, GraphDataPoint[]] | [];
 
 export type QueryInput = {

--- a/src/brokers/broker-details/components/Overview/Metrics/utils/units.ts
+++ b/src/brokers/broker-details/components/Overview/Metrics/utils/units.ts
@@ -175,8 +175,8 @@ export const units: Units = {
       value,
       type.units,
       type.divisor,
-      initialUnit,
-      preferredUnit,
+      initialUnit ?? '',
+      preferredUnit ?? '',
     );
 
     if (useRound) {
@@ -186,7 +186,7 @@ export const units: Units = {
         type.units,
         type.divisor,
         converted.unit,
-        preferredUnit,
+        preferredUnit ?? '',
       );
     }
 

--- a/src/brokers/broker-details/components/Overview/Overview.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Overview.container.tsx
@@ -47,6 +47,7 @@ import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { Loading } from '@app/shared-components/Loading/Loading';
 import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
 import { useGetBrokerCR } from '@app/k8s/customHooks';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 const useGetIssuerCa = (
   cr: BrokerCR,
@@ -60,7 +61,7 @@ const useGetIssuerCa = (
         version: 'v1',
         kind: 'Issuer',
       },
-      namespace: cr.metadata.namespace,
+      namespace: cr.metadata?.namespace,
       name: acceptorIssuer,
     });
   if (!loadedIssuers || loadErrorIssuers) {
@@ -79,7 +80,7 @@ const useGetTlsSecret = (cr: BrokerCR, acceptor: Acceptor) => {
     },
     name: secretName,
     isList: true,
-    namespace: cr.metadata.namespace,
+    namespace: cr.metadata?.namespace,
   });
 
   const secret = secrets.find((secret) => secret.metadata?.name === secretName);
@@ -103,11 +104,11 @@ const SecretDownloadLink: FC<SecretDownloadLinkProps> = ({ secret }) => {
     <a
       href={
         'data:application/pem-certificate-chain;base64,' +
-        secret.data['tls.crt']
+        secret.data?.['tls.crt']
       }
-      download={secret.metadata.name + '.pem'}
+      download={secret.metadata?.name + '.pem'}
     >
-      {secret.metadata.name + '.pem'}
+      {secret.metadata?.name + '.pem'}
     </a>
   );
 };
@@ -129,7 +130,7 @@ const HelpConnectAcceptor: FC<HelperConnectAcceptorProps> = ({
   const [secret, loaded, loadError] = useGetTlsSecret(cr, acceptor);
   const ingressHost = getIssuerIngressHostForAcceptor(cr, acceptor, 0);
   const [copied, setCopied] = useState(false);
-  const isSecuredByToken = cr.spec.adminUser === undefined;
+  const isSecuredByToken = cr.spec?.adminUser === undefined;
 
   const clipboardCopyFunc = (text: string) => {
     navigator.clipboard.writeText(text.toString());
@@ -180,9 +181,9 @@ const HelpConnectAcceptor: FC<HelperConnectAcceptorProps> = ({
                 onClick={() =>
                   window.open(
                     'ns/' +
-                      cr.metadata.namespace +
+                      cr.metadata?.namespace +
                       '/secrets/' +
-                      cr.spec.deploymentPlan.extraMounts.secrets[0],
+                      cr.spec?.deploymentPlan?.extraMounts?.secrets?.[0],
                   )
                 }
               >
@@ -257,7 +258,7 @@ const ConnectivityHelper: FC<IssuerSecretsDownloaderProps> = ({ cr }) => {
                   )}
                 </DescriptionListDescription>
               </DescriptionListGroup>
-              {cr.spec.acceptors.map((acceptor) => (
+              {cr.spec?.acceptors?.map((acceptor) => (
                 <HelpConnectAcceptor
                   cr={cr}
                   acceptor={acceptor}
@@ -287,7 +288,7 @@ const Annotations: FC<IssuerSecretsDownloaderProps> = ({ cr }) => {
             </Button>
           }
         >
-          {cr.metadata.annotations ? (
+          {cr.metadata?.annotations ? (
             Object.entries(cr.metadata.annotations).map(
               (annotations, index) => (
                 <Label key={index} variant="filled">
@@ -320,7 +321,7 @@ const Labels: FC<IssuerSecretsDownloaderProps> = ({ cr }) => {
             </Button>
           }
         >
-          {cr.metadata.labels ? (
+          {cr.metadata?.labels ? (
             Object.entries(cr.metadata.labels).map((label, index) => (
               <Label
                 key={index}
@@ -349,8 +350,18 @@ const Labels: FC<IssuerSecretsDownloaderProps> = ({ cr }) => {
 export const OverviewContainer: FC = () => {
   const { t } = useTranslation();
   const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
+  const {
+    brokerCr: cr,
+    isLoading,
+    error,
+  } = useGetBrokerCR(name ?? '', namespace ?? '');
 
-  const { brokerCr: cr, isLoading, error } = useGetBrokerCR(name, namespace);
+  if (!name || !namespace) {
+    return (
+      <GenericError message={t('Namespace and broker name are required.')} />
+    );
+  }
+
   if (isLoading) {
     return <Loading />;
   }
@@ -377,7 +388,7 @@ export const OverviewContainer: FC = () => {
       <Metrics
         name={name}
         namespace={namespace}
-        size={cr.spec?.deploymentPlan?.size}
+        size={cr.spec?.deploymentPlan?.size ?? 0}
       />
       <Divider />
       {cr.spec?.restricted ? (

--- a/src/brokers/broker-details/components/Resources/Resources.container.tsx
+++ b/src/brokers/broker-details/components/Resources/Resources.container.tsx
@@ -17,6 +17,7 @@ import { useParams } from 'react-router-dom-v5-compat';
 import { ResourcesList } from './components/ResourcesList';
 import { ErrorCircleOIcon, SearchIcon } from '@patternfly/react-icons';
 import { K8sResourceCommonWithData } from '@app/k8s/types';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 export const ResourcesContainer: FC = () => {
   //states
@@ -67,6 +68,13 @@ export const ResourcesContainer: FC = () => {
       namespace: namespace,
     });
   const [prevStatefulStes, setPrevStatefulSets] = useState(statefulsets);
+
+  // Early return if required params are missing
+  if (!namespace || !name) {
+    return (
+      <GenericError message={t('Namespace and broker name are required.')} />
+    );
+  }
 
   // Filter Resources
   const filterBrokerResources = (

--- a/src/brokers/broker-details/components/Resources/components/ResourcesList.tsx
+++ b/src/brokers/broker-details/components/Resources/components/ResourcesList.tsx
@@ -24,18 +24,15 @@ export const ResourcesTable: FC<ResourcesTableProps> = ({ data }) => {
     { title: t('Created'), id: 'created' },
   ];
 
-  const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
+  const [activeSortIndex, setActiveSortIndex] = useState<number>(0);
   const [activeSortDirection, setActiveSortDirection] = useState<
-    'asc' | 'desc' | null
-  >(null);
+    'asc' | 'desc'
+  >('asc');
 
   const getSortableRowValues = (
     broker: BrokerCR,
   ): (string | number | undefined)[] => {
-    const {
-      metadata: { name, creationTimestamp },
-      kind,
-    } = broker;
+    const { metadata: { name, creationTimestamp } = {}, kind } = broker;
     const status = name && kind && creationTimestamp ? 'Created' : 'Loading';
     return [name, kind, status, creationTimestamp];
   };

--- a/src/brokers/broker-details/components/Resources/components/ResourcesRow.tsx
+++ b/src/brokers/broker-details/components/Resources/components/ResourcesRow.tsx
@@ -13,10 +13,7 @@ type ResourcesRowProps = {
 };
 
 export const ResourcesRow: FC<ResourcesRowProps> = ({ obj }) => {
-  const {
-    metadata: { name, creationTimestamp },
-    kind,
-  } = obj;
+  const { metadata: { name, creationTimestamp } = {}, kind } = obj;
   const isDataFetched = name && kind && creationTimestamp;
   const { t } = useTranslation();
 
@@ -33,7 +30,7 @@ export const ResourcesRow: FC<ResourcesRowProps> = ({ obj }) => {
     }
   };
 
-  const resourceBasePath = getResourceBasePath(kind);
+  const resourceBasePath = getResourceBasePath(kind ?? '');
 
   return (
     <Tr>
@@ -41,8 +38,8 @@ export const ResourcesRow: FC<ResourcesRowProps> = ({ obj }) => {
         {resourceBasePath ? (
           <ResourceLink
             kind={kind}
-            name={obj.metadata.name}
-            namespace={obj.metadata.namespace}
+            name={obj.metadata?.name}
+            namespace={obj.metadata?.namespace}
           />
         ) : (
           name
@@ -59,7 +56,7 @@ export const ResourcesRow: FC<ResourcesRowProps> = ({ obj }) => {
         )}
       </Td>
       <Td>
-        <Timestamp timestamp={creationTimestamp} />
+        {creationTimestamp ? <Timestamp timestamp={creationTimestamp} /> : '-'}
       </Td>
     </Tr>
   );

--- a/src/brokers/broker-details/components/broker-pods/PodsList.container.tsx
+++ b/src/brokers/broker-details/components/broker-pods/PodsList.container.tsx
@@ -42,7 +42,7 @@ export const PodsContainer: FC = () => {
   };
 
   useEffect(() => {
-    if (loaded && !loadError) {
+    if (loaded && !loadError && name) {
       setLoading(false);
       const filteredPods = filterBrokerPods(pods, name);
       setBrokerPods(filteredPods);

--- a/src/brokers/broker-details/components/broker-pods/components/PodRow.tsx
+++ b/src/brokers/broker-details/components/broker-pods/components/PodRow.tsx
@@ -13,10 +13,7 @@ export type PodRowProps = RowProps<BrokerCR> & {
 };
 
 export const PodRow: FC<PodRowProps> = ({ obj, activeColumnIDs, columns }) => {
-  const {
-    metadata: { name, creationTimestamp, namespace },
-    status,
-  } = obj;
+  const { metadata: { name, creationTimestamp, namespace } = {}, status } = obj;
 
   const readyCount = status?.containerStatuses
     ? status.containerStatuses.filter(
@@ -46,7 +43,7 @@ export const PodRow: FC<PodRowProps> = ({ obj, activeColumnIDs, columns }) => {
         {restarts}
       </TableData>
       <TableData id={columns[4].id} activeColumnIDs={activeColumnIDs}>
-        <Timestamp timestamp={creationTimestamp} />
+        {creationTimestamp ? <Timestamp timestamp={creationTimestamp} /> : '-'}
       </TableData>
     </>
   );

--- a/src/brokers/broker-details/components/yaml/Yaml.container.tsx
+++ b/src/brokers/broker-details/components/yaml/Yaml.container.tsx
@@ -7,12 +7,23 @@ import { useTranslation } from '@app/i18n/i18n';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useGetBrokerCR } from '@app/k8s/customHooks';
 import { ErrorState } from '@app/shared-components/ErrorState/ErrorState';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 const YamlContainer: FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
-  const { brokerCr, isLoading, error } = useGetBrokerCR(name, namespace);
+  const { brokerCr, isLoading, error } = useGetBrokerCR(
+    name ?? '',
+    namespace ?? '',
+  );
+
+  if (!name || !namespace) {
+    return (
+      <GenericError message={t('Namespace and broker name are required.')} />
+    );
+  }
+
   if (isLoading) {
     return <Loading />;
   }

--- a/src/brokers/update-broker/UpdateBroker.container.tsx
+++ b/src/brokers/update-broker/UpdateBroker.container.tsx
@@ -16,6 +16,7 @@ import {
 import { ArtemisReducerOperations712 } from '@app/reducers/7.12/reducer';
 import { ArtemisReducerOperationsRestricted } from '@app/reducers/restricted/reducer';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 export const UpdateBrokerPage: FC = () => {
   const navigate = useNavigate();
@@ -26,7 +27,7 @@ export const UpdateBrokerPage: FC = () => {
 
   const [brokerModel, dispatch] = useReducer(
     artemisCrReducer,
-    newArtemisCR(namespace),
+    newArtemisCR(namespace ?? ''),
   );
 
   const [hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
@@ -68,7 +69,7 @@ export const UpdateBrokerPage: FC = () => {
 
         // If this is a restricted broker, initialize UI-only fields with defaults
         // These fields are used by the UI to know which secrets to validate
-        if (broker.spec.restricted) {
+        if (broker.spec?.restricted) {
           dispatch({
             operation:
               ArtemisReducerOperationsRestricted.setACTIVEMQ_ARTEMIS_MANAGER_CA_SECRET_NAME,
@@ -125,6 +126,9 @@ export const UpdateBrokerPage: FC = () => {
     handleRedirect();
   }
 
+  const { cr } = brokerModel;
+  if (!cr) return <GenericError />;
+
   return (
     <BrokerCreationFormState.Provider value={brokerModel}>
       <BrokerCreationFormDispatch.Provider value={dispatch}>
@@ -138,7 +142,7 @@ export const UpdateBrokerPage: FC = () => {
           />
         )}
         <AddBroker
-          onSubmit={() => k8sUpdateBroker(brokerModel.cr)}
+          onSubmit={() => k8sUpdateBroker(cr)}
           onCancel={handleRedirect}
           isUpdatingExisting
           reloadExisting={k8sGetBroker}

--- a/src/brokers/view-brokers/BrokersList.container.tsx
+++ b/src/brokers/view-brokers/BrokersList.container.tsx
@@ -33,8 +33,8 @@ export const BrokersContainer: FC = () => {
   });
 
   const onEditBroker = (broker: BrokerCR) => {
-    const namespace = broker.metadata.namespace;
-    const name = broker.metadata.name;
+    const namespace = broker.metadata?.namespace;
+    const name = broker.metadata?.name;
     navigate(`/k8s/ns/${namespace}/edit-broker/${name}`);
   };
 
@@ -67,13 +67,13 @@ export const BrokersContainer: FC = () => {
         onDeleteButtonClick={onDeleteBroker}
         isModalOpen={isModalOpen}
         onOpenModal={onOpenModal}
-        name={selectedBroker?.metadata?.name}
+        name={selectedBroker?.metadata?.name ?? ''}
       />
       <BrokersList
         brokers={brokers}
         loadError={loadError}
         loaded={loaded}
-        namespace={namespace}
+        namespace={namespace ?? ''}
         onOpenModal={onOpenModal}
         onEditBroker={onEditBroker}
       />

--- a/src/brokers/view-brokers/components/BrokersList/BrokerRow.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokerRow.tsx
@@ -47,7 +47,7 @@ const ConditionModal: FC<ConditionModalProps> = ({ status }) => {
   return (
     <>
       <Button variant="link" onClick={() => setIsOpen(true)}>
-        {status ? getConditionString(status?.conditions) : '-'}
+        {status?.conditions ? getConditionString(status.conditions) : '-'}
       </Button>
       <Modal
         bodyAriaLabel="Status report"
@@ -114,15 +114,12 @@ export const BrokerRow: FC<BrokerRowProps> = ({
   onOpenModal,
 }) => {
   const { t } = useTranslation();
-  const {
-    metadata: { name, creationTimestamp, namespace },
-    status,
-  } = obj;
+  const { metadata: { name, creationTimestamp, namespace } = {}, status } = obj;
 
   const size = obj.spec?.deploymentPlan?.size;
 
   const readyCondition = status
-    ? obj.status.conditions.find(
+    ? obj.status?.conditions.find(
         (c: K8sResourceCondition) => c.type === BrokerConditionTypes.Ready,
       )
     : null;
@@ -153,7 +150,7 @@ export const BrokerRow: FC<BrokerRowProps> = ({
         {size}
       </TableData>
       <TableData id={columns[4].id} activeColumnIDs={activeColumnIDs}>
-        <Timestamp timestamp={creationTimestamp} />
+        {creationTimestamp ? <Timestamp timestamp={creationTimestamp} /> : '-'}
       </TableData>
       <TableData id={columns[5].id} activeColumnIDs={activeColumnIDs}>
         <ActionsColumn items={rowActions} />

--- a/src/k8s/certManagerUtils.ts
+++ b/src/k8s/certManagerUtils.ts
@@ -85,7 +85,8 @@ export const createClusterIssuerChainOfTrust = async (
       await k8sCreate({ model: ClusterIssuerModel, data: rootIssuer });
     } catch (error) {
       // If it already exists, that's fine
-      if (!error?.message?.includes('already exists')) {
+      const message = error instanceof Error ? error.message : '';
+      if (!message.includes('already exists')) {
         throw error;
       }
     }
@@ -94,7 +95,8 @@ export const createClusterIssuerChainOfTrust = async (
     try {
       await k8sCreate({ model: CertModel, data: rootCACert });
     } catch (error) {
-      if (!error?.message?.includes('already exists')) {
+      const message = error instanceof Error ? error.message : '';
+      if (!message.includes('already exists')) {
         throw error;
       }
     }
@@ -106,7 +108,7 @@ export const createClusterIssuerChainOfTrust = async (
   } catch (error) {
     throw new Error(
       `Failed to create ClusterIssuer chain of trust: ${
-        error?.message || error
+        error instanceof Error ? error.message : String(error)
       }`,
     );
   }
@@ -298,7 +300,9 @@ export const createTrustBundle = async (
     return trustBundle;
   } catch (error) {
     throw new Error(
-      `Failed to create Trust Bundle: ${error?.message || error}`,
+      `Failed to create Trust Bundle: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
     );
   }
 };

--- a/src/k8s/customHooks.ts
+++ b/src/k8s/customHooks.ts
@@ -20,8 +20,9 @@ export const useGetIngressDomain = (): {
   const k8sGetBroker = () => {
     setLoading(true);
     k8sGet({ model: IngressDomainModel, name: 'cluster' })
-      .then((ing: Ingress) => {
-        setDomain(ing.spec.domain);
+      .then((result) => {
+        const ing = result as Ingress;
+        setDomain(ing.spec?.domain ?? '');
       })
       .catch((e) => {
         setError(e.message);

--- a/src/reducers/7.12/tsconfig.json
+++ b/src/reducers/7.12/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "strict": true,
-    "composite": false
-  },
-  "include": ["./**/*.ts"]
-}

--- a/src/reducers/7.13/tsconfig.json
+++ b/src/reducers/7.13/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "strict": true,
-    "composite": false
-  },
-  "include": ["./**/*.ts"]
-}

--- a/src/reducers/restricted/tsconfig.json
+++ b/src/reducers/restricted/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "strict": true,
-    "composite": false
-  },
-  "include": ["./**/*.ts"]
-}

--- a/src/reducers/tsconfig.json
+++ b/src/reducers/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "strict": true,
-    "composite": false
-  },
-  "include": ["./*.ts"]
-}

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/AcceptorConfigPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/AcceptorConfigPage.tsx
@@ -32,6 +32,7 @@ import { SelectExposeMode } from './SelectExposeMode/SelectExposeMode';
 import { OtherParameters } from './OtherParameters/OtherParameters';
 import { ListPresets } from './ListPresets/ListPresets';
 import { CertSecretSelector } from '../../../CertSecretSelector/CertSecretSelector';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 type AcceptorProps = {
   configName: string;
@@ -45,6 +46,8 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
 }) => {
   const { cr } = useContext(BrokerCreationFormState);
   const dispatch = useContext(BrokerCreationFormDispatch);
+  const { t } = useTranslation();
+  if (!cr) return <GenericError />;
 
   const selectedClass = getConfigFactoryClass(cr, configType, configName);
   const port = getConfigPort(cr, configType, configName);
@@ -177,7 +180,8 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
     { value: 'invm', label: 'InVM', disabled: false },
   ];
 
-  const { t } = useTranslation();
+  const acceptor = getAcceptor(cr, configName);
+
   return (
     <>
       <FormFieldGroup
@@ -241,11 +245,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
             >
               <Checkbox
                 label={t('Expose')}
-                isChecked={
-                  getAcceptor(cr, configName)
-                    ? getAcceptor(cr, configName).expose
-                    : false
-                }
+                isChecked={getAcceptor(cr, configName)?.expose ?? false}
                 name={'check-expose' + configType + configName}
                 id={'check-expose' + configType + configName}
                 onChange={(_event, v) =>
@@ -264,11 +264,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
             <SelectExposeMode
               configName={configName}
               configType={configType}
-              selectedExposeMode={
-                getAcceptor(cr, configName)
-                  ? getAcceptor(cr, configName).exposeMode
-                  : ''
-              }
+              selectedExposeMode={getAcceptor(cr, configName)?.exposeMode ?? ''}
               setSelectedExposeMode={(v) =>
                 dispatch({
                   operation: ArtemisReducerOperations712.setAcceptorExposeMode,
@@ -344,12 +340,7 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 label={t('ingressHost')}
                 name={'ingressHost' + configType + configName}
                 id={'ingressHost' + configType + configName}
-                value={
-                  getAcceptor(cr, configName) &&
-                  getAcceptor(cr, configName).ingressHost
-                    ? getAcceptor(cr, configName).ingressHost
-                    : ''
-                }
+                value={getAcceptor(cr, configName)?.ingressHost ?? ''}
                 onChange={(_event, v) =>
                   dispatch({
                     operation:
@@ -420,34 +411,36 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
           }
         >
           <CertSecretSelector
-            namespace={cr.metadata.namespace}
+            namespace={cr.metadata?.namespace ?? ''}
             isCa={false}
             configType={configType}
             configName={configName}
             canSetCustomNames
           />
           <CertSecretSelector
-            namespace={cr.metadata.namespace}
+            namespace={cr.metadata?.namespace ?? ''}
             isCa={true}
             configType={configType}
             configName={configName}
           />
         </FormFieldGroup>
       )}
-      {configType === ConfigType.acceptors && cr.spec.resourceTemplates && (
-        <FormFieldGroup
-          header={
-            <FormFieldGroupHeader
-              titleText={{
-                text: t('Presets'),
-                id: 'field-group-configuration-annotations' + configName,
-              }}
-            />
-          }
-        >
-          <ListPresets acceptor={getAcceptor(cr, configName)} />
-        </FormFieldGroup>
-      )}
+      {configType === ConfigType.acceptors &&
+        cr.spec?.resourceTemplates &&
+        acceptor && (
+          <FormFieldGroup
+            header={
+              <FormFieldGroupHeader
+                titleText={{
+                  text: t('Presets'),
+                  id: 'field-group-configuration-annotations' + configName,
+                }}
+              />
+            }
+          >
+            <ListPresets acceptor={acceptor} />
+          </FormFieldGroup>
+        )}
     </>
   );
 };

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/ListPresets/ListPresets.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/ListPresets/ListPresets.tsx
@@ -18,6 +18,7 @@ import {
 import { ResourceTemplate } from '@app/k8s/types';
 import { SelectIssuerDrawer } from '../../../../../../SelectIssuerDrawer/SelectIssuerDrawer';
 import { ConfirmDeleteModal } from '../../ConfirmDeleteModal/ConfirmDeleteModal';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 type ResourceTemplateProps = {
   resourceTemplate: ResourceTemplate;
 };
@@ -26,10 +27,18 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
   const { cr } = useContext(BrokerCreationFormState);
   const { t } = useTranslation();
   const dispatch = useContext(BrokerCreationFormDispatch);
+  if (!cr) return <GenericError />;
   const acceptor = getAcceptorFromCertManagerResourceTemplate(
     cr,
     resourceTemplate,
   );
+
+  if (!acceptor || !acceptor.name) {
+    return <GenericError />;
+  }
+
+  const acceptorName = acceptor.name;
+
   return (
     <FormFieldGroupExpandable
       isExpanded
@@ -38,7 +47,7 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
         <FormFieldGroupHeader
           titleText={{
             text: t('Cert-Manager issuer & Ingress exposure'),
-            id: 'nested-field-cert-manager-annotation-id' + acceptor.name,
+            id: 'nested-field-cert-manager-annotation-id' + acceptorName,
           }}
           titleDescription={t('Configuration items for the preset')}
           actions={
@@ -48,7 +57,7 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
                 dispatch({
                   operation:
                     ArtemisReducerOperations712.deletePEMGenerationForAcceptor,
-                  payload: acceptor.name,
+                  payload: acceptorName,
                 })
               }
             />
@@ -59,13 +68,13 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
       <FormGroup label={t('Issuer')} isRequired>
         <SelectIssuerDrawer
           selectedIssuer={
-            resourceTemplate.annotations['cert-manager.io/issuer']
+            resourceTemplate.annotations?.['cert-manager.io/issuer'] ?? ''
           }
           setSelectedIssuer={(issuer: string) => {
             dispatch({
               operation: ArtemisReducerOperations712.updateAnnotationIssuer,
               payload: {
-                acceptorName: acceptor.name,
+                acceptorName: acceptorName,
                 newIssuer: issuer,
               },
             });
@@ -74,7 +83,7 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
             dispatch({
               operation: ArtemisReducerOperations712.updateAnnotationIssuer,
               payload: {
-                acceptorName: acceptor.name,
+                acceptorName: acceptorName,
                 newIssuer: '',
               },
             });
@@ -91,16 +100,13 @@ type ListPresetsProps = {
 
 export const ListPresets: FC<ListPresetsProps> = ({ acceptor }) => {
   const { cr } = useContext(BrokerCreationFormState);
+  if (!cr) return <GenericError />;
   const certManagerRt = getCertManagerResourceTemplateFromAcceptor(
     cr,
     acceptor,
   );
   if (!certManagerRt) {
-    return <></>;
+    return null;
   }
-  return (
-    <>
-      {certManagerRt && <CertManagerPreset resourceTemplate={certManagerRt} />}
-    </>
-  );
+  return <CertManagerPreset resourceTemplate={certManagerRt} />;
 };

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/OtherParameters/OtherParameters.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/OtherParameters/OtherParameters.tsx
@@ -17,6 +17,7 @@ import {
 import { TrashIcon } from '@patternfly/react-icons';
 import { ConfigType } from '../../../../ConfigurationPage';
 import { useTranslation } from '@app/i18n/i18n';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 type ParamProps = {
   paramKey: string;
@@ -32,8 +33,11 @@ const Param: FC<ParamProps> = ({
   configName,
 }) => {
   const { cr } = useContext(BrokerCreationFormState);
-  const otherParams = getConfigOtherParams(cr, configType, configName);
   const dispatch = useContext(BrokerCreationFormDispatch);
+  const [newKey, setNewKey] = useState(key);
+  const [newValue, setNewValue] = useState(value);
+  if (!cr) return <GenericError />;
+  const otherParams = getConfigOtherParams(cr, configType, configName);
   const updateOtherParams = (prevKey: string, key: string, value: string) => {
     const params = new Map(otherParams);
     if (prevKey) {
@@ -64,8 +68,6 @@ const Param: FC<ParamProps> = ({
   const deleteOtherParam = (key: string) => {
     updateOtherParams(key, '', '');
   };
-  const [newKey, setNewKey] = useState(key);
-  const [newValue, setNewValue] = useState(value);
   return (
     <InputGroup>
       <InputGroupItem isFill>
@@ -111,13 +113,14 @@ export const OtherParameters: FC<OtherParametersProps> = ({
 }) => {
   const { t } = useTranslation();
   const { cr } = useContext(BrokerCreationFormState);
+  const dispatch = useContext(BrokerCreationFormDispatch);
+  if (!cr) return <GenericError />;
   const otherParams = getConfigOtherParams(cr, configType, configName);
   let newParamSuffix = 0;
   const newParamBaseName = 'key';
   while (otherParams.has(newParamBaseName + newParamSuffix)) {
     newParamSuffix += 1;
   }
-  const dispatch = useContext(BrokerCreationFormDispatch);
   const addNewParam = (key: string, value: string) => {
     const params = new Map(otherParams);
     params.set(key, value);

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/PresetAlertPopover/PresetAlertPopover.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/PresetAlertPopover/PresetAlertPopover.tsx
@@ -8,6 +8,7 @@ import {
 import { useTranslation } from '@app/i18n/i18n';
 import { Alert, Icon, Popover } from '@patternfly/react-core';
 import { BellIcon, WarningTriangleIcon } from '@patternfly/react-icons';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 type PresetCautionProps = {
   configType: ConfigType;
@@ -22,16 +23,15 @@ export const PresetAlertPopover: FC<PresetCautionProps> = ({
 }) => {
   const { cr } = useContext(BrokerCreationFormState);
   const { t } = useTranslation();
-  const hasCertManagerPreset =
-    configType === ConfigType.acceptors
-      ? getCertManagerResourceTemplateFromAcceptor(
-          cr,
-          getAcceptor(cr, configName),
-        ) !== undefined
-      : false;
+  if (!cr) return <GenericError />;
 
-  if (!hasCertManagerPreset) {
-    return <></>;
+  const acceptor = getAcceptor(cr, configName);
+  if (
+    configType !== ConfigType.acceptors ||
+    !acceptor ||
+    !getCertManagerResourceTemplateFromAcceptor(cr, acceptor)
+  ) {
+    return null;
   }
 
   return (

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigSection.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigSection.tsx
@@ -16,6 +16,7 @@ import { AcceptorConfigPage } from './AcceptorConfigPage/AcceptorConfigPage';
 import { PresetButton } from './PresetButton/PresetButton';
 import { ConfirmDeleteModal } from './ConfirmDeleteModal/ConfirmDeleteModal';
 import { ConfigRenamingModal } from './ConfigRenamingModal/ConfigRenamingModal';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 export type AcceptorConfigSectionProps = {
   configType: ConfigType;
@@ -43,6 +44,8 @@ export const AcceptorConfigSection: FC<AcceptorConfigSectionProps> = ({
   };
 
   const { cr } = useContext(BrokerCreationFormState);
+  if (!cr) return <GenericError />;
+  const acceptor = getAcceptor(cr, configName);
   return (
     <FormFieldGroupExpandable
       isExpanded
@@ -56,8 +59,8 @@ export const AcceptorConfigSection: FC<AcceptorConfigSectionProps> = ({
           titleDescription={configName + "'s details"}
           actions={
             <>
-              {configType === ConfigType.acceptors && (
-                <PresetButton acceptor={getAcceptor(cr, configName)} />
+              {configType === ConfigType.acceptors && acceptor && (
+                <PresetButton acceptor={acceptor} />
               )}
               <ConfigRenamingModal initName={configName} />
               <ConfirmDeleteModal

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/ConfigRenamingModal/ConfigRenamingModal.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/ConfigRenamingModal/ConfigRenamingModal.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../../../../../reducers/7.12/reducer';
 import { useTranslation } from '../../../../../../../i18n/i18n';
 import { ConfigType, ConfigTypeContext } from '../../../ConfigurationPage';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 export type ConfigRenamingModalProps = {
   initName: string;
 };
@@ -28,8 +29,12 @@ export const ConfigRenamingModal: FC<ConfigRenamingModalProps> = ({
   const dispatch = useContext(BrokerCreationFormDispatch);
   const [newName, setNewName] = useState(initName);
   const [toolTip, setTooltip] = useState('');
-  const [validateStatus, setValidateStatus] = useState(null);
+  const [validateStatus, setValidateStatus] = useState<ValidatedOptions>(
+    ValidatedOptions.default,
+  );
   const { cr } = useContext(BrokerCreationFormState);
+  const [isOpen, setIsOpen] = useState(false);
+  if (!cr) return <GenericError />;
   const uniqueSet = listConfigs(configType, cr, 'set') as Set<string>;
 
   const handleNewName = () => {
@@ -70,7 +75,6 @@ export const ConfigRenamingModal: FC<ConfigRenamingModalProps> = ({
     return true;
   };
 
-  const [isOpen, setIsOpen] = useState(false);
   return (
     <>
       <Modal

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
@@ -31,12 +31,14 @@ import {
 import { SelectIssuerDrawer } from '../../../../../SelectIssuerDrawer/SelectIssuerDrawer';
 import { useHasCertManager } from '@app/k8s/customHooks';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
+
 type PreconfigurationButtonProps = {
   acceptor: Acceptor;
 };
 
 export type WithAcceptorProps = {
-  acceptor?: Acceptor;
+  acceptor: Acceptor;
 };
 
 interface AddIssuerAnnotationModalProps extends WithAcceptorProps {
@@ -56,12 +58,12 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
   const dispatch = useContext(BrokerCreationFormDispatch);
   const [selectedIssuer, setSelectedIssuer] = useState<string>('');
   const [selectedAcceptor, setSelectedAcceptor] = useState<string>(
-    initialAcceptor ? initialAcceptor.name : '',
+    initialAcceptor?.name ?? '',
   );
   const [prevInitialAcceptor, setPrevInitialAcceptor] =
     useState(initialAcceptor);
   if (prevInitialAcceptor !== initialAcceptor) {
-    setSelectedAcceptor(initialAcceptor ? initialAcceptor.name : '');
+    setSelectedAcceptor(initialAcceptor?.name ?? '');
     setPrevInitialAcceptor(initialAcceptor);
   }
 
@@ -82,12 +84,13 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
   };
 
   const { cr } = useContext(BrokerCreationFormState);
-  const hasACertManagerAnnotation =
-    getCertManagerResourceTemplateFromAcceptor(cr, initialAcceptor) !==
-    undefined;
   const [showCertManagerForm, setShowCertManagerForm] = useState(false);
   const { hasCertManager, isLoading: isLoadingCertManagerAvailability } =
     useHasCertManager();
+  if (!cr) return <GenericError />;
+  const hasACertManagerAnnotation =
+    getCertManagerResourceTemplateFromAcceptor(cr, initialAcceptor) !==
+    undefined;
   const isCertMangerDependencySatisfied =
     hasCertManager && !isLoadingCertManagerAvailability;
   const onChange = (event: React.FormEvent<HTMLInputElement>) => {
@@ -219,6 +222,7 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
 export const PresetButton: FC<PreconfigurationButtonProps> = ({ acceptor }) => {
   const { t } = useTranslation();
   const [showPresetModal, setShowPresetModal] = useState(false);
+
   return (
     <>
       <AddPresetModal

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorsConfigPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorsConfigPage.tsx
@@ -21,6 +21,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 import { AcceptorConfigSection } from './AcceptorConfigSection/AcceptorConfigSection';
 import { useTranslation } from '@app/i18n/i18n';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 type AcceptorsConfigProps = {
   brokerId: number;
@@ -30,10 +31,11 @@ export const AcceptorsConfigPage: FC<AcceptorsConfigProps> = ({ brokerId }) => {
   const { t } = useTranslation();
   const { cr } = useContext(BrokerCreationFormState);
   const configType = useContext(ConfigTypeContext);
+  const dispatch = useContext(BrokerCreationFormDispatch);
+  if (!cr) return <GenericError />;
   const configs = listConfigs(configType, cr) as {
     name: string;
   }[];
-  const dispatch = useContext(BrokerCreationFormDispatch);
 
   const addNewConfig = () => {
     if (configType === ConfigType.acceptors) {

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/AccessControlPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/AccessControlPage.tsx
@@ -36,10 +36,10 @@ export const AccessControlPage: FC = () => {
             id={'id-switch-console-auth-token'}
             label={t('RBAC enabled')}
             labelOff={t('RBAC disabled')}
-            isChecked={!cr.spec?.adminUser}
+            isChecked={!cr?.spec?.adminUser}
             onChange={(_event, value: boolean) => handleAuthChange(value)}
           />
-          {!cr.spec?.adminUser && (
+          {!cr?.spec?.adminUser && (
             <FormFieldGroup
               header={
                 <FormFieldGroupHeader

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/SecurityRules.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/SecurityRules.tsx
@@ -19,6 +19,7 @@ import {
   ArtemisReducerOperations713,
   getSecurityRoles,
 } from '@app/reducers/7.13/reducer';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 type SecurityRulesProps = {
   name: string;
@@ -27,8 +28,11 @@ type SecurityRulesProps = {
 
 const SecurityRule: FC<SecurityRulesProps> = ({ name: key, value: value }) => {
   const { cr } = useContext(BrokerCreationFormState);
-  const securityRoles = getSecurityRoles(cr);
   const dispatch = useContext(BrokerCreationFormDispatch);
+  const [newKey, setNewKey] = useState(key);
+  const [newValue, setNewValue] = useState(value);
+  if (!cr) return <GenericError />;
+  const securityRoles = getSecurityRoles(cr);
   const updateSecurityRole = (prevKey: string, key: string, value: string) => {
     // find the index of the prevKey
     let prevKeyIndex = 0;
@@ -60,8 +64,6 @@ const SecurityRule: FC<SecurityRulesProps> = ({ name: key, value: value }) => {
   const deleteSecurityRule = (key: string) => {
     updateSecurityRole(key, '', '');
   };
-  const [newKey, setNewKey] = useState(key);
-  const [newValue, setNewValue] = useState(value);
   return (
     <InputGroup>
       <InputGroupItem isFill>
@@ -99,10 +101,10 @@ const SecurityRule: FC<SecurityRulesProps> = ({ name: key, value: value }) => {
 export const SecurityRoles: FC = () => {
   const { t } = useTranslation();
   const { cr } = useContext(BrokerCreationFormState);
-  const securityRoles = getSecurityRoles(cr);
   const dispatch = useContext(BrokerCreationFormDispatch);
-
   const [filterValue, setFilterValue] = useState<string>('');
+  if (!cr) return <GenericError />;
+  const securityRoles = getSecurityRoles(cr);
 
   const addNewSecurityRule = (key: string, value: string) => {
     const newSecurityRoles = new Map([...securityRoles, [key, value]]);

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/ServiceAccountSelector.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/ServiceAccountSelector.tsx
@@ -23,7 +23,7 @@ export const ServiceAccountSelector: React.FunctionComponent = () => {
   const dispatch = useContext(BrokerCreationFormDispatch);
 
   const { serviceAccounts, isLoading, error } = useGetServiceAccounts(
-    cr.metadata?.namespace,
+    cr?.metadata?.namespace ?? '',
   );
 
   return (
@@ -78,7 +78,7 @@ export const ServiceAccountSelector: React.FunctionComponent = () => {
 
         {!isLoading && !error && (
           <FormSelect
-            value={cr.spec?.deploymentPlan?.podSecurity?.serviceAccountName}
+            value={cr?.spec?.deploymentPlan?.podSecurity?.serviceAccountName}
             onChange={(_event, value) =>
               dispatch({
                 operation: ArtemisReducerOperations713.setServiceAccount,
@@ -95,8 +95,8 @@ export const ServiceAccountSelector: React.FunctionComponent = () => {
             {serviceAccounts.map((option, index) => (
               <FormSelectOption
                 key={index}
-                value={option.metadata.name}
-                label={option.metadata.name}
+                value={option.metadata?.name ?? ''}
+                label={option.metadata?.name ?? ''}
               />
             ))}
           </FormSelect>

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/UserMappings.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AccessControl/UserMappings.tsx
@@ -44,7 +44,10 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 import styles from '@patternfly/react-styles/css/components/Form/form';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { TypeaheadSelect } from '@patternfly/react-templates';
+import {
+  TypeaheadSelect,
+  TypeaheadSelectOption,
+} from '@patternfly/react-templates';
 
 const createJaasConfig = async (
   name: string,
@@ -103,7 +106,7 @@ export const SelectUserMappings: FC = () => {
       kind: 'Secret',
     },
     isList: true,
-    namespace: cr.metadata.namespace,
+    namespace: cr?.metadata?.namespace,
   });
   const [alertSecret, setAlertSecret] = useState<Error>();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -127,12 +130,14 @@ export const SelectUserMappings: FC = () => {
     );
   }, [secrets]);
 
-  const selectOptions = useMemo(() => {
+  const selectOptions = useMemo<TypeaheadSelectOption[]>(() => {
     return validSecrets
-      .map((jaasConfig) => ({
-        value: jaasConfig.metadata.name,
-        content: jaasConfig.metadata.name,
-      }))
+      .flatMap((jaasConfig) => {
+        const name = jaasConfig.metadata?.name;
+
+        // Return an array with the object if it's valid, or an empty array to filter it out
+        return name ? [{ value: name, content: name }] : [];
+      })
       .sort((a, b) => String(a.content).localeCompare(String(b.content)));
   }, [validSecrets]);
 
@@ -147,18 +152,18 @@ export const SelectUserMappings: FC = () => {
     );
   }
 
-  const selectedSecret =
-    cr.spec?.deploymentPlan?.extraMounts?.secrets[0] !== undefined
-      ? validSecrets.filter(
-          (secret) =>
-            secret.metadata?.name ===
-            cr.spec.deploymentPlan.extraMounts.secrets[0],
-        )[0]
-      : undefined;
+  const secretNames = cr?.spec?.deploymentPlan?.extraMounts?.secrets;
+  const selectedSecretName = secretNames?.[0];
+
+  const selectedSecret = selectedSecretName
+    ? validSecrets.find(
+        (secret) => secret.metadata?.name === selectedSecretName,
+      )
+    : undefined;
 
   // if the user just selected a jaas config, override the previous security
   // roles
-  if (needsInitializingSR && selectedSecret?.data['extra-roles.properties']) {
+  if (needsInitializingSR && selectedSecret?.data?.['extra-roles.properties']) {
     setNeedsInitializingSR(false);
     dispatch({
       operation: ArtemisReducerOperations713.setSecurityRoles,
@@ -185,12 +190,15 @@ export const SelectUserMappings: FC = () => {
   };
 
   const triggerJaasConfigCreation = () => {
+    const namespace = cr?.metadata?.namespace;
+    if (!namespace) {
+      setAlertSecret(
+        new Error(t('Namespace is not available. Cannot create jaas config.')),
+      );
+      return;
+    }
     setAlertSecret(undefined);
-    createJaasConfig(
-      newJaasConfigName,
-      newJaasConfigAdmin,
-      cr.metadata.namespace,
-    )
+    createJaasConfig(newJaasConfigName, newJaasConfigAdmin, namespace)
       .then(() => {
         setIsExpanded(false);
         dispatch({
@@ -203,6 +211,19 @@ export const SelectUserMappings: FC = () => {
         setAlertSecret(reason);
       });
   };
+
+  const handleRebuildSecurityRoles = () => {
+    const encodedRoles = selectedSecret?.data?.['extra-roles.properties'];
+
+    if (!encodedRoles) {
+      return;
+    }
+    dispatch({
+      operation: ArtemisReducerOperations713.setSecurityRoles,
+      payload: getInitSecurityRoles(atob(encodedRoles).split('\n')),
+    });
+  };
+
   return (
     <FormGroup
       label={t('Jaas login module')}
@@ -292,7 +313,7 @@ export const SelectUserMappings: FC = () => {
                     const selection = String(selectedValue);
                     onSelectSecret(selection);
                   }}
-                  selected={cr.spec?.deploymentPlan?.extraMounts?.secrets[0]}
+                  selected={cr?.spec?.deploymentPlan?.extraMounts?.secrets?.[0]}
                 />
               </SplitItem>
               <SplitItem>
@@ -308,9 +329,9 @@ export const SelectUserMappings: FC = () => {
                         onClick={() =>
                           window.open(
                             'ns/' +
-                              selectedSecret.metadata.namespace +
+                              selectedSecret.metadata?.namespace +
                               '/secrets/' +
-                              selectedSecret.metadata.name +
+                              selectedSecret.metadata?.name +
                               '/edit',
                           )
                         }
@@ -326,17 +347,7 @@ export const SelectUserMappings: FC = () => {
                     >
                       <Button
                         variant="link"
-                        onClick={() =>
-                          dispatch({
-                            operation:
-                              ArtemisReducerOperations713.setSecurityRoles,
-                            payload: getInitSecurityRoles(
-                              atob(
-                                selectedSecret.data['extra-roles.properties'],
-                              ).split('\n'),
-                            ),
-                          })
-                        }
+                        onClick={handleRebuildSecurityRoles}
                       >
                         {t('rebuild security roles')}
                       </Button>
@@ -380,21 +391,27 @@ export const SelectUserMappings: FC = () => {
                           </Tr>
                         </Thead>
                         <Tbody>
-                          {atob(
-                            selectedSecret.data[
-                              'k8s-users-to-roles-mapping.properties'
-                            ],
-                          )
-                            .split('\n')
-                            .filter((line) => line.match('.+=.+'))
-                            .map((line, index) => {
-                              return (
+                          {selectedSecret.data?.[
+                            'k8s-users-to-roles-mapping.properties'
+                          ] ? (
+                            atob(
+                              selectedSecret.data[
+                                'k8s-users-to-roles-mapping.properties'
+                              ],
+                            )
+                              .split('\n')
+                              .filter((line) => line.match('.+=.+'))
+                              .map((line, index) => (
                                 <Tr key={index}>
                                   <Td> {line.split('=')[0]} </Td>
                                   <Td> {line.split('=')[1]} </Td>
                                 </Tr>
-                              );
-                            })}
+                              ))
+                          ) : (
+                            <Tr>
+                              <Td colSpan={2}>{t('No data available')}</Td>
+                            </Tr>
+                          )}
                         </Tbody>
                       </Table>
                       {}
@@ -413,17 +430,21 @@ export const SelectUserMappings: FC = () => {
                           </Tr>
                         </Thead>
                         <Tbody>
-                          {atob(selectedSecret.data['extra-users.properties'])
-                            .split('\n')
-                            .filter((line) => line.match('.+=.+'))
-                            .map((line, index) => {
-                              return (
+                          {selectedSecret.data?.['extra-users.properties'] ? (
+                            atob(selectedSecret.data['extra-users.properties'])
+                              .split('\n')
+                              .filter((line) => line.match('.+=.+'))
+                              .map((line, index) => (
                                 <Tr key={index}>
                                   <Td> {line.split('=')[0]} </Td>
                                   <Td> {line.split('=')[1]} </Td>
                                 </Tr>
-                              );
-                            })}
+                              ))
+                          ) : (
+                            <Tr>
+                              <Td colSpan={2}>{t('No data available')}</Td>
+                            </Tr>
+                          )}
                         </Tbody>
                       </Table>
                       {}
@@ -442,17 +463,21 @@ export const SelectUserMappings: FC = () => {
                           </Tr>
                         </Thead>
                         <Tbody>
-                          {atob(selectedSecret.data['extra-roles.properties'])
-                            .split('\n')
-                            .filter((line) => line.match('.+=.+'))
-                            .map((line, index) => {
-                              return (
+                          {selectedSecret.data?.['extra-roles.properties'] ? (
+                            atob(selectedSecret.data['extra-roles.properties'])
+                              .split('\n')
+                              .filter((line) => line.match('.+=.+'))
+                              .map((line, index) => (
                                 <Tr key={index}>
                                   <Td> {line.split('=')[0]} </Td>
                                   <Td> {line.split('=')[1]} </Td>
                                 </Tr>
-                              );
-                            })}
+                              ))
+                          ) : (
+                            <Tr>
+                              <Td colSpan={2}>{t('No data available')}</Td>
+                            </Tr>
+                          )}
                         </Tbody>
                       </Table>
                       {}

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.test.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.test.tsx
@@ -3,6 +3,7 @@ import { CertSecretSelector } from './CertSecretSelector';
 import {
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
+  EditorType,
 } from '@app/reducers/reducer';
 import {
   useK8sWatchResource,
@@ -70,10 +71,16 @@ describe('CertSecretSelector', () => {
 
   const mocDispatch = jest.fn();
   const mockFormState = {
+    editorType: EditorType.BROKER,
     cr: {
-      apiVersion: 'v1',
+      apiVersion: 'broker.amq.io/v1beta1',
+      kind: 'ActiveMQArtemis',
       metadata: { name: 'test-broker', namespace: 'test-namespace' },
+      spec: {},
     },
+    hasChanges: false,
+    yamlHasUnsavedChanges: false,
+    brokerVersion: '7.12' as const,
   };
   const mockSecrets = [
     {

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
@@ -48,6 +48,7 @@ import {
   TypeaheadSelect,
   TypeaheadSelectOption,
 } from '@patternfly/react-templates';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 /**
  * This function will generate a certificate for the targeted configType with
@@ -133,53 +134,63 @@ const GenerateCertificateModal: FC<GenerateCertificateModalProps> = ({
   const dispatch = useContext(BrokerCreationFormDispatch);
   const [selectedIssuer, setSelectedIssuer] = useState<string>('');
   const { cr } = useContext(BrokerCreationFormState);
+  if (!cr) return <GenericError />;
 
   const isConsole = !(
     configType === ConfigType.acceptors || configType === ConfigType.connectors
   );
-  const dnsNames = [].concat(
-    ...[...Array(cr.spec.deploymentPlan.size).keys()].map((i) =>
+  const dnsNames = [...Array(cr.spec?.deploymentPlan?.size).keys()].flatMap(
+    (i) =>
       isConsole
         ? [
-            cr.metadata.name +
+            cr.metadata?.name +
               '-wconsj-' +
               i +
               '-svc-rte-' +
-              cr.metadata.namespace +
+              cr.metadata?.namespace +
               '.' +
-              cr.spec.ingressDomain,
-            cr.metadata.name +
+              cr.spec?.ingressDomain,
+            cr.metadata?.name +
               '-wconsj-' +
               i +
               '-svc-ing-' +
-              cr.metadata.namespace +
+              cr.metadata?.namespace +
               '.' +
-              cr.spec.ingressDomain,
-            cr.metadata.name + '-wconsj-' + i + '-svc.' + cr.metadata.namespace,
+              cr.spec?.ingressDomain,
+            cr.metadata?.name +
+              '-wconsj-' +
+              i +
+              '-svc.' +
+              cr.metadata?.namespace,
           ]
         : [
-            cr.metadata.name +
+            cr.metadata?.name +
               '-ss-' +
               i +
               '.' +
-              cr.metadata.name +
+              cr.metadata?.name +
               '-hdls-svc.' +
-              cr.metadata.namespace +
+              cr.metadata?.namespace +
               '.svc.cluster.local',
           ],
-    ),
   );
-  const certName = cr.metadata.name + '-' + configType + '-cert';
-  const commonName = cr.metadata.name + '-' + configType;
-  const secretName = cr.metadata.name + '-' + configType + '-cert-secret';
+  const certName = cr.metadata?.name + '-' + configType + '-cert';
+  const commonName = cr.metadata?.name + '-' + configType;
+  const secretName = cr.metadata?.name + '-' + configType + '-cert-secret';
   const handleGenerateCertificate = () => {
     if (selectedIssuer === '') {
       return;
     }
+    const namespace = cr.metadata?.namespace;
+    if (!namespace) {
+      setError(t('Namespace is not available. Cannot generate certificate.'));
+      return;
+    }
+
     createCert(
       selectedIssuer,
       certName,
-      cr.metadata.namespace,
+      namespace,
       commonName,
       secretName,
       dnsNames,
@@ -196,7 +207,7 @@ const GenerateCertificateModal: FC<GenerateCertificateModalProps> = ({
           operation: operation,
           payload: {
             name: configName,
-            secret: cr.metadata.name + '-' + configType + '-cert-secret',
+            secret: cr.metadata?.name + '-' + configType + '-cert-secret',
             isCa: false,
           },
         });
@@ -245,7 +256,7 @@ const GenerateCertificateModal: FC<GenerateCertificateModalProps> = ({
           <DescriptionListGroup>
             <DescriptionListTerm>{t('namespace')}</DescriptionListTerm>
             <DescriptionListDescription>
-              {cr.metadata.namespace}
+              {cr.metadata?.namespace}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
@@ -324,25 +335,25 @@ type CreateSecretOptionsPropTypes = {
  * @returns A list of options for the typeahead select.
  */
 const useCreateSecretOptions = ({
-  customOptions,
+  customOptions = [],
   certManagerSecrets,
   legacySecrets,
 }: CreateSecretOptionsPropTypes): TypeaheadSelectOption[] => {
   const nonptlsSecrets = certManagerSecrets
     .filter((secret) => {
-      return !secret.metadata.name.endsWith('-ptls');
+      return !!secret.metadata?.name && !secret.metadata.name.endsWith('-ptls');
     })
-    .map((option) => option.metadata.name);
+    .map((option) => option.metadata!.name);
   const filteredCustomOptions = customOptions.filter(
     (option) =>
       !nonptlsSecrets.find((s) => s === option) &&
-      !legacySecrets.find((s) => s.metadata.name.startsWith(option)),
+      !legacySecrets.find((s) => s.metadata?.name?.startsWith(option)),
   );
   const options = [
     ...filteredCustomOptions,
     ...nonptlsSecrets,
-    ...legacySecrets.map((option) => option.metadata.name),
-  ];
+    ...legacySecrets.map((option) => option.metadata?.name),
+  ].filter((option): option is string => typeof option === 'string');
   return options.map((option) => {
     return { content: option, value: option };
   });
@@ -359,11 +370,12 @@ const useCreateSecretOptions = ({
  * otherwise.
  */
 const isLegacySecret = (secret: K8sResourceCommonWithData): boolean => {
-  return (
+  return !!(
     !(
       secret.metadata?.annotations &&
       'aa-spp-generated' in secret.metadata.annotations
     ) &&
+    secret.data &&
     hasKey(secret.data, 'broker.ks') &&
     hasKey(secret.data, 'keyStorePassword') &&
     hasKey(secret.data, 'client.ts') &&
@@ -416,7 +428,7 @@ const isKnownCertManagerSecret = (
   certManagerSecrets: K8sResourceCommonWithData[],
 ): boolean => {
   const theSecret = certManagerSecrets.filter((value) => {
-    return value.metadata.name === selectedSecret;
+    return value.metadata?.name === selectedSecret;
   });
   return theSecret.length === 1;
 };
@@ -563,7 +575,9 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
    * Retrieves the currently selected secret name from the form state for the
    * given configuration.
    */
-  const selectedSecret = getConfigSecret(cr, configType, configName, isCa);
+  const selectedSecret = cr
+    ? getConfigSecret(cr, configType, configName, isCa)
+    : undefined;
   const customOptions = selectedSecret ? [selectedSecret] : [];
   /**
    * Generates the list of selectable options for the typeahead input by combining
@@ -590,6 +604,11 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
         .sort((a, b) => String(a.content).localeCompare(String(b.content))),
     [options],
   );
+
+  const showCertTooltipRef = useRef<HTMLButtonElement>(null);
+  const [parseError, setParseError] = useState(null);
+
+  if (!cr) return <GenericError />;
 
   /**
    * Clears the selected secret for the current configuration in the form state.
@@ -667,32 +686,30 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
   };
 
   /**
-   * A ref to the button that shows the certificate info, used for positioning the tooltip.
-   */
-  const showCertTooltipRef = useRef<HTMLButtonElement>(null);
-  /**
    * Fetches and parses the certificate details from the selected secret and opens
    * the details modal. It handles both CA and regular TLS secrets.
    */
-
-  const [parseError, setParseError] = useState(null);
   const showCertInfo = () => {
     setParseError(null);
     const theSecret = certManagerSecrets.filter((value) => {
-      return value.metadata.name === selectedSecret;
+      return value.metadata?.name === selectedSecret;
     });
     let pem: string;
     try {
-      if (theSecret.length !== 1) {
+      if (
+        theSecret.length !== 1 ||
+        !theSecret[0].data ||
+        !theSecret[0].metadata?.name
+      ) {
         setParseError(t('only support tls format secret from cert-manager'));
         // clear the message after 10 seconds
         setTimeout(() => setParseError(null), 10000);
         return;
       }
       if (isCa) {
-        Object.keys(theSecret[0].data).forEach((key) => {
-          pem = base64.decode(theSecret[0].data[key]);
-        });
+        const keys = Object.keys(theSecret[0].data);
+        if (keys.length === 0) return;
+        pem = base64.decode(theSecret[0].data[keys[keys.length - 1]]);
       } else {
         pem = base64.decode(theSecret[0].data['tls.crt']);
       }
@@ -717,8 +734,13 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
    * Retrieves the cert-manager resource template from the acceptor configuration.
    * This is used to determine if a preset alert should be shown.
    */
-  const certManagerResourceTemplate =
-    getCertManagerResourceTemplateFromAcceptor(cr, getAcceptor(cr, configName));
+  const acceptor =
+    configType === ConfigType.acceptors
+      ? getAcceptor(cr, configName)
+      : undefined;
+  const certManagerResourceTemplate = acceptor
+    ? getCertManagerResourceTemplateFromAcceptor(cr, acceptor)
+    : undefined;
 
   return (
     <FormGroup
@@ -799,6 +821,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
             ref={showCertTooltipRef}
             isDisabled={
               stringSelectedSecret === '' ||
+              !selectedSecret ||
               !isKnownCertManagerSecret(selectedSecret, certManagerSecrets)
             }
           >

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/ConsoleConfigPage/ConsoleConfigPage.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/ConsoleConfigPage/ConsoleConfigPage.tsx
@@ -23,6 +23,7 @@ import { BrokerCR } from '@app/k8s/types';
 import { ConfigType } from '../ConfigurationPage';
 import { CertSecretSelector } from '../CertSecretSelector/CertSecretSelector';
 import { useTranslation } from '@app/i18n/i18n';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 export type ConsoleConfigProps = {
   brokerId: number;
@@ -58,6 +59,8 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
     return false;
   };
 
+  const [execOnlyOnce, setExecOnlyOnce] = useState(true);
+  if (!cr) return <GenericError />;
   const exposeConsole = GetConsoleExpose(cr);
   const exposeMode = GetConsoleExposeMode(cr);
   const isSSLEnabled = GetConsoleSSLEnabled(cr);
@@ -88,7 +91,6 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
     { value: ExposeMode.ingress, label: 'Ingress', disabled: false },
   ];
 
-  const [execOnlyOnce, setExecOnlyOnce] = useState(true);
   if (execOnlyOnce) {
     setExecOnlyOnce(false);
     setConsoleExpose(exposeConsole);
@@ -128,8 +130,8 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
           <FormSelect
             label={t('console expose mode')}
             value={exposeMode}
-            onChange={(_event, value: ExposeMode) =>
-              setConsoleExposeMode(value)
+            onChange={(_event, value: string) =>
+              setConsoleExposeMode(value as ExposeMode)
             }
             aria-label="formselect-expose-mode-aria-label"
           >
@@ -151,7 +153,7 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
           ouiaId="BasicSwitch-console-ssl"
         />
       </FormFieldGroupExpandable>
-      {isSSLEnabled && (
+      {isSSLEnabled && cr.metadata?.namespace && (
         <FormFieldGroup
           header={
             <FormFieldGroupHeader
@@ -163,13 +165,13 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
           }
         >
           <CertSecretSelector
-            namespace={cr.metadata.namespace}
+            namespace={cr.metadata?.namespace}
             isCa={false}
             configType={ConfigType.console}
             configName={'console'}
           />
           <CertSecretSelector
-            namespace={cr.metadata.namespace}
+            namespace={cr.metadata?.namespace}
             isCa={true}
             configType={ConfigType.console}
             configName={'console'}

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -28,7 +28,7 @@ export const FormView: FC = () => {
   const { t } = useTranslation();
   const formState = useContext(BrokerCreationFormState);
   const { cr } = useContext(BrokerCreationFormState);
-  const targetNs = cr.metadata.namespace;
+  const targetNs = cr?.metadata?.namespace;
   const dispatch = useContext(BrokerCreationFormDispatch);
 
   const handleNameChange = (name: string) => {
@@ -53,8 +53,8 @@ export const FormView: FC = () => {
     { value: '7.13', label: 'AMQ 7.13', disabled: false },
   ];
 
-  const crName = formState.cr.metadata.name;
-  const replicas = formState.cr.spec.deploymentPlan.size;
+  const crName = formState.cr?.metadata?.name;
+  const replicas = formState.cr?.spec?.deploymentPlan?.size;
   return (
     <>
       <Form isHorizontal>
@@ -155,13 +155,13 @@ export const FormView: FC = () => {
         type="wizard"
         aria-label={t('broker configuration')}
       >
-        {formState.cr.spec.restricted && <RestrictedConfiguration />}
-        {!formState.cr.spec.restricted && (
+        {formState.cr?.spec?.restricted && <RestrictedConfiguration />}
+        {!formState.cr?.spec?.restricted && (
           <LegacyBrokerProperties
             brokerId={0}
             perBrokerProperties={false}
-            crName={crName}
-            targetNs={targetNs}
+            crName={crName ?? ''}
+            targetNs={targetNs ?? ''}
           />
         )}
       </PageSection>

--- a/src/shared-components/FormView/RestrictedMode/ControlPlane/CertSecretFinder.tsx
+++ b/src/shared-components/FormView/RestrictedMode/ControlPlane/CertSecretFinder.tsx
@@ -82,7 +82,7 @@ export const CertSecretFinder: FC<CertSecretFinderProps> = ({
     certs: x509.X509Certificate[];
     pem: string;
   } | null>(null);
-  const namespace = formState.cr.metadata.namespace;
+  const namespace = formState.cr?.metadata?.namespace;
 
   /**
    * Read the validation result from formState (set by useSecretWatcher at top level)
@@ -165,7 +165,7 @@ export const CertSecretFinder: FC<CertSecretFinderProps> = ({
     } catch (error) {
       setParseError(
         t('Failed to load certificate: {{error}}', {
-          error: error?.message || 'Unknown error',
+          error: error instanceof Error ? error.message : 'Unknown error',
         }),
       );
     }
@@ -287,11 +287,11 @@ export const CertSecretFinder: FC<CertSecretFinderProps> = ({
               {showGenerateButton
                 ? t(
                     'Required certificate missing in the {{namespace}} namespace. Either import or generate one.',
-                    { namespace: formState.cr.metadata.namespace },
+                    { namespace: formState.cr?.metadata?.namespace },
                   )
                 : t(
                     'Required certificate missing in the {{namespace}} namespace. Please import one.',
-                    { namespace: formState.cr.metadata.namespace },
+                    { namespace: formState.cr?.metadata?.namespace },
                   )}
             </HelperTextItem>
           </HelperText>

--- a/src/shared-components/FormView/RestrictedMode/ControlPlane/ControlPlane.tsx
+++ b/src/shared-components/FormView/RestrictedMode/ControlPlane/ControlPlane.tsx
@@ -76,7 +76,7 @@ export const ControlPlane: FC = () => {
 
         <CertSecretFinder
           expectedSecretNames={[
-            `${cr.metadata.name}-broker-cert`,
+            `${cr?.metadata?.name}-broker-cert`,
             'broker-cert',
           ]}
           validationFlag={MandatorySecretsToWatchFor.BROKER_CERT}

--- a/src/shared-components/FormView/RestrictedMode/ControlPlane/GenerateRestrictedCertModal.tsx
+++ b/src/shared-components/FormView/RestrictedMode/ControlPlane/GenerateRestrictedCertModal.tsx
@@ -58,11 +58,11 @@ export const GenerateRestrictedCertModal: FC<
     if (!cr) {
       return null;
     }
-    const brokerName = cr.metadata.name;
+    const brokerName = cr.metadata?.name;
     // Generate specific DNS names for each broker pod
-    const dnsNames = [...Array(cr.spec.deploymentPlan.size).keys()].map(
+    const dnsNames = [...Array(cr.spec?.deploymentPlan?.size).keys()].map(
       (i) =>
-        `${brokerName}-ss-${i}.${brokerName}-hdls-svc.${cr.metadata.namespace}.svc.cluster.local`,
+        `${brokerName}-ss-${i}.${brokerName}-hdls-svc.${cr.metadata?.namespace}.svc.cluster.local`,
     );
 
     const certSecretName = `${brokerName}-broker-cert`;
@@ -97,6 +97,11 @@ export const GenerateRestrictedCertModal: FC<
     if (selectedIssuer === '' || commonName === '') {
       return;
     }
+    const namespace = cr?.metadata?.namespace;
+    if (!namespace) {
+      setError(t('Namespace is not available. Cannot generate certificate.'));
+      return;
+    }
 
     try {
       // ALL certificates are created in the broker namespace
@@ -104,7 +109,7 @@ export const GenerateRestrictedCertModal: FC<
       await createRestrictedCert(
         selectedIssuer,
         certDetails.certName,
-        cr.metadata.namespace,
+        namespace,
         commonName,
         certDetails.secretName,
         certDetails.isCA,
@@ -112,7 +117,9 @@ export const GenerateRestrictedCertModal: FC<
       );
       handleModalToggle();
     } catch (err) {
-      setError(err?.message || 'Failed to generate certificate');
+      setError(
+        err instanceof Error ? err.message : 'Failed to generate certificate',
+      );
     }
   };
 
@@ -162,7 +169,7 @@ export const GenerateRestrictedCertModal: FC<
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Namespace')}</DescriptionListTerm>
             <DescriptionListDescription>
-              {cr.metadata.namespace}
+              {cr?.metadata?.namespace}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>

--- a/src/shared-components/FormView/RestrictedMode/DataPlane/DataPlane.tsx
+++ b/src/shared-components/FormView/RestrictedMode/DataPlane/DataPlane.tsx
@@ -53,8 +53,8 @@ export const DataPlane: FC = () => {
     }
   }
 
-  const brokerName = formState.cr.metadata.name;
-  const namespace = formState.cr.metadata.namespace;
+  const brokerName = formState.cr?.metadata?.name;
+  const namespace = formState.cr?.metadata?.namespace;
   const jaasSecretName = `${brokerName}-jaas-config-bp`;
   const amqpsSecretName = 'amqps-pem';
   const jaasSecretHref = `/k8s/ns/${namespace}/secrets/${jaasSecretName}`;
@@ -73,8 +73,8 @@ export const DataPlane: FC = () => {
 
   const { amqpsSecretStatus } = useCreateAmqpsPemSecret({
     amqpsEnabled: acceptorEnabled,
-    brokerName,
-    namespace,
+    brokerName: brokerName ?? '',
+    namespace: namespace ?? '',
   });
 
   const { jaasSecretStatus } = useCreateJaasConfigPropertiesSecret({
@@ -84,7 +84,7 @@ export const DataPlane: FC = () => {
     securityDomain,
     roleName,
     clientCN,
-    namespace,
+    namespace: namespace ?? '',
     jaasSecretName,
   });
 

--- a/src/shared-components/FormView/RestrictedMode/DataPlane/dataPlaneSecretHooks.ts
+++ b/src/shared-components/FormView/RestrictedMode/DataPlane/dataPlaneSecretHooks.ts
@@ -47,6 +47,13 @@ export const useCreateAmqpsPemSecret = ({
   });
 
   const reconcileAmqps = async (runId: number) => {
+    if (!namespace || !brokerName) {
+      updateAmqpsStatus(
+        'error',
+        t('Namespace or broker name is not available. Cannot manage secrets.'),
+      );
+      return;
+    }
     if (!amqpsEnabled) {
       updateAmqpsStatus(
         'idle',
@@ -71,7 +78,11 @@ export const useCreateAmqpsPemSecret = ({
           resource: { metadata: { name: 'amqps-pem', namespace } },
         });
       } catch (error) {
-        const statusCode = error?.code || error?.response?.status;
+        const err = error as {
+          code?: number;
+          response?: { status?: number };
+        } | null;
+        const statusCode = err?.code || err?.response?.status;
         if (statusCode !== 404) {
           throw error;
         }
@@ -98,9 +109,10 @@ export const useCreateAmqpsPemSecret = ({
       }
     } catch (error) {
       if (reconcileRunRef.current === runId) {
+        const err = error as { message?: string } | null;
         updateAmqpsStatus(
           'error',
-          error?.message || t('Failed to manage amqps-pem secret.'),
+          err?.message || t('Failed to manage amqps-pem secret.'),
         );
       }
     }
@@ -151,6 +163,13 @@ export const useCreateJaasConfigPropertiesSecret = ({
   });
 
   const reconcileJaas = async (runId: number) => {
+    if (!namespace) {
+      updateJaasStatus(
+        'error',
+        t('Namespace is not available. Cannot manage JAAS secret.'),
+      );
+      return;
+    }
     if (!jaasEnabled) {
       updateJaasStatus(
         'idle',
@@ -189,7 +208,11 @@ export const useCreateJaasConfigPropertiesSecret = ({
           resource: { metadata: { name: jaasSecretName, namespace } },
         });
       } catch (error) {
-        const statusCode = error?.code || error?.response?.status;
+        const err = error as {
+          code?: number;
+          response?: { status?: number };
+        } | null;
+        const statusCode = err?.code || err?.response?.status;
         if (statusCode !== 404) {
           throw error;
         }
@@ -218,9 +241,10 @@ export const useCreateJaasConfigPropertiesSecret = ({
       }
     } catch (error) {
       if (reconcileRunRef.current === runId) {
+        const err = error as { message?: string } | null;
         updateJaasStatus(
           'error',
-          error?.message || t('Failed to manage JAAS secret.'),
+          err?.message || t('Failed to manage JAAS secret.'),
         );
       }
     }

--- a/src/shared-components/FormView/RestrictedMode/Monitoring/monitoringHooks.ts
+++ b/src/shared-components/FormView/RestrictedMode/Monitoring/monitoringHooks.ts
@@ -45,7 +45,7 @@ export const useCreateMonitoringResources = ({
     useState<MonitoringResourceStatus>();
   const reconcileRunRef = useRef(0);
   const prevSignatureRef = useRef<string>('');
-  const prevEnabledRef = useRef<boolean>(enabled);
+  const prevEnabledRef = useRef<boolean>(enabled ?? false);
 
   const updateStatus = useCallback(
     (
@@ -652,8 +652,8 @@ export const useCreateMonitoringResources = ({
     prevSignatureRef.current = signature;
     reconcileRunRef.current += 1;
     const wasEnabled = prevEnabledRef.current;
-    prevEnabledRef.current = enabled;
-    const forceRecreateCert = enabled && !wasEnabled;
+    prevEnabledRef.current = enabled ?? false;
+    const forceRecreateCert = (enabled ?? false) && !wasEnabled;
     void reconcile(reconcileRunRef.current, forceRecreateCert);
   }
 

--- a/src/shared-components/FormView/RestrictedMode/RestrictedConfiguration.tsx
+++ b/src/shared-components/FormView/RestrictedMode/RestrictedConfiguration.tsx
@@ -23,6 +23,7 @@ import { ControlPlane } from './ControlPlane/ControlPlane';
 import { DataPlane } from './DataPlane/DataPlane';
 import { Monitoring } from './Monitoring/Monitoring';
 import { OperatorConfiguration } from './OperatorConfiguration/OperatorConfiguration';
+import { GenericError } from '@app/shared-components/GenericError/GenericError';
 
 enum ConfigEntry {
   controlPlane = 'controlplane',
@@ -47,20 +48,22 @@ export const RestrictedConfiguration: FC = () => {
     [ConfigEntry.operatorConfiguration]: t('Operator configuration'),
   };
 
+  const namespace = formState.cr?.metadata?.namespace;
+  const brokerName = formState.cr?.metadata?.name;
+
   // Watch for required secrets - hooks return the found secret name or empty string
   // These are calculated during render, no cascading updates!
   // Note: Trust-manager Bundles automatically create secrets in namespaces, so we just watch for the secret itself
-  const operatorCaSecret = useSecretWatcher(formState.cr.metadata.namespace, [
+  const operatorCaSecret = useSecretWatcher(namespace ?? '', [
     formState.ACTIVEMQ_ARTEMIS_MANAGER_CA_SECRET_NAME,
   ]);
-  const brokerCertSecret = useSecretWatcher(formState.cr.metadata.namespace, [
-    `${formState.cr.metadata.name}-broker-cert`,
+  const brokerCertSecret = useSecretWatcher(namespace ?? '', [
+    `${brokerName ?? ''}-broker-cert`,
     'broker-cert',
   ]);
-  const prometheusCertSecret = useSecretWatcher(
-    formState.cr.metadata.namespace,
-    [formState.BASE_PROMETHEUS_CERT_SECRET_NAME],
-  );
+  const prometheusCertSecret = useSecretWatcher(namespace ?? '', [
+    formState.BASE_PROMETHEUS_CERT_SECRET_NAME,
+  ]);
 
   const [prevOperatorCaSecret, setPrevOperatorCaSecret] =
     useState(operatorCaSecret);
@@ -99,6 +102,12 @@ export const RestrictedConfiguration: FC = () => {
         actualSecretName: prometheusCertSecret,
       },
     });
+  }
+
+  if (!namespace || !brokerName) {
+    return (
+      <GenericError message={t('Namespace and broker name are required.')} />
+    );
   }
 
   return (

--- a/src/shared-components/FormView/SelectIssuerDrawer/SelectIssuerDrawer.tsx
+++ b/src/shared-components/FormView/SelectIssuerDrawer/SelectIssuerDrawer.tsx
@@ -57,7 +57,7 @@ export const SelectIssuerDrawer: FC<SelectIssuerDrawerProps> = ({
       kind: isClusterIssuer ? 'ClusterIssuer' : 'Issuer',
     },
     isList: true,
-    namespace: isClusterIssuer ? '' : cr.metadata.namespace,
+    namespace: isClusterIssuer ? '' : cr?.metadata?.namespace,
   });
   const [alertIssuer, setAlertIssuer] = useState<Error>();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -70,11 +70,12 @@ export const SelectIssuerDrawer: FC<SelectIssuerDrawerProps> = ({
 
   const selectOptions = useMemo(() => {
     return validIssuers
+      .filter((issuer) => issuer.metadata?.name !== null)
       .map((issuer) => ({
-        value: issuer.metadata.name,
-        content: issuer.metadata.name,
+        value: issuer.metadata!.name!,
+        content: issuer.metadata!.name!,
       }))
-      .sort((a, b) => String(a.content).localeCompare(String(b.content)));
+      .sort((a, b) => a.content.localeCompare(b.content));
   }, [validIssuers]);
 
   if (!loaded) {
@@ -99,14 +100,16 @@ export const SelectIssuerDrawer: FC<SelectIssuerDrawerProps> = ({
   };
 
   const triggerChainOfTrustCreation = () => {
+    const namespace = cr?.metadata?.namespace;
+    const ingressDomain = cr?.spec?.ingressDomain;
+    if (!namespace || !ingressDomain) {
+      setAlertIssuer(new Error('Namespace and ingress domain are required'));
+      return;
+    }
     setAlertIssuer(undefined);
     const createPromise = isClusterIssuer
-      ? createClusterIssuerChainOfTrust(newIssuer, cr.spec.ingressDomain)
-      : createIssuerChainOfTrust(
-          newIssuer,
-          cr.metadata.namespace,
-          cr.spec.ingressDomain,
-        );
+      ? createClusterIssuerChainOfTrust(newIssuer, ingressDomain)
+      : createIssuerChainOfTrust(newIssuer, namespace, ingressDomain);
 
     createPromise
       .then(() => {

--- a/src/shared-components/GenericError/GenericError.tsx
+++ b/src/shared-components/GenericError/GenericError.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import { useTranslation } from '@app/i18n/i18n';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { ErrorCircleOIcon } from '@patternfly/react-icons';
+
+export type GenericErrorProps = {
+  message?: string;
+};
+
+export const GenericError: FC<GenericErrorProps> = ({ message }) => {
+  const { t } = useTranslation();
+  return (
+    <EmptyState variant={EmptyStateVariant.sm}>
+      <EmptyStateHeader
+        titleText={t('Something went wrong')}
+        icon={<EmptyStateIcon icon={ErrorCircleOIcon} />}
+        headingLevel="h4"
+      />
+      <EmptyStateBody>
+        {message ??
+          t(
+            'An unexpected error occurred. Required data is not available. Please try again later.',
+          )}
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};

--- a/src/shared-components/YamlEditorView/YamlEditorView.tsx
+++ b/src/shared-components/YamlEditorView/YamlEditorView.tsx
@@ -55,7 +55,7 @@ export const YamlEditorView: FC<YamlEditorViewPropTypes> = ({
   };
   useInterval(removeLastAlert, alerts.length > 0 ? 2000 : null);
 
-  const [currentYaml, setCurrentYaml] = useState<string>();
+  const [currentYaml, setCurrentYaml] = useState<string>('');
   const [yamlParseError, setYamlParserError] = useState<YAMLParseError>();
 
   const getUniqueId = () => new Date().getTime();
@@ -106,13 +106,15 @@ export const YamlEditorView: FC<YamlEditorViewPropTypes> = ({
       <AlertGroup isToast isLiveRegion>
         {alerts.map(({ key, variant, title }) => (
           <Alert
-            variant={AlertVariant[variant]}
+            variant={variant}
             title={title}
             actionClose={
               <AlertActionCloseButton
                 title={title as string}
                 variantLabel={`${variant} alert`}
-                onClose={() => removeAlert(key)}
+                onClose={() =>
+                  key !== undefined && key !== null && removeAlert(key)
+                }
               />
             }
             key={key}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "jsx": "react-jsx",
     "allowJs": true,
-    "strict": false,
+    "strict": true,
     "noUnusedLocals": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Enabled strict TypeScript checking across the entire codebase by resolving all remaining type errors in `UI/form` components and consolidating per-reducer type checks into a single typecheck.

fixes: [issue#170](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/170)