### PR TITLE
Re-enable type safety for Reducers 7.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Extract translations
         run: yarn i18n && git diff --exit-code locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
 
+      - name: check strict mode for reducers/7.12
+        run: yarn typecheck:7.12 2>&1 | grep "src/reducers/7.12/" && exit 1 || echo ok
+
       - name: Build project
         run: yarn run build
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "yarn clean && NODE_ENV=production yarn webpack",
     "build-dev": "yarn clean && yarn webpack",
+    "typecheck:7.12": "tsc -p src/reducers/7.12/tsconfig.json --noEmit",
     "clean": "rm -rf dist",
     "format:all": "prettier --config ./.prettierrc.yml --write './src/**/*'",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",

--- a/src/k8s/types.ts
+++ b/src/k8s/types.ts
@@ -21,7 +21,7 @@ export type Acceptor = {
   expose?: boolean;
   exposeMode?: ExposeMode;
   ingressHost?: string;
-  name?: string;
+  name: string;
   port?: number;
   protocols?: string;
   sslEnabled?: boolean;
@@ -37,7 +37,7 @@ export type Connector = {
   exposeMode?: ExposeMode;
   host?: string;
   ingressHost?: string;
-  name?: string;
+  name: string;
   port?: number;
   protocols?: string;
   sslEnabled?: boolean;

--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -11,12 +11,12 @@ describe('test the creation broker reducer', () => {
     const newState = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newState.cr.spec.acceptors).toHaveLength(1);
-    expect(newState.cr.spec.acceptors[0].name).toBe('acceptors0');
-    expect(newState.cr.spec.acceptors[0].port).toBe(5555);
-    expect(newState.cr.spec.acceptors[0].protocols).toBe('ALL');
-    expect(newState.cr.spec.brokerProperties).toHaveLength(1);
-    expect(newState.cr.spec.brokerProperties).toContain(
+    expect(newState.cr?.spec?.acceptors).toHaveLength(1);
+    expect(newState.cr?.spec?.acceptors?.[0].name).toBe('acceptors0');
+    expect(newState.cr?.spec?.acceptors?.[0].port).toBe(5555);
+    expect(newState.cr?.spec?.acceptors?.[0].protocols).toBe('ALL');
+    expect(newState.cr?.spec?.brokerProperties).toHaveLength(1);
+    expect(newState.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -26,12 +26,12 @@ describe('test the creation broker reducer', () => {
     const newState = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newState.cr.spec.connectors).toHaveLength(1);
-    expect(newState.cr.spec.connectors[0].name).toBe('connectors0');
-    expect(newState.cr.spec.connectors[0].port).toBe(5555);
-    expect(newState.cr.spec.connectors[0].host === 'localhost');
-    expect(newState.cr.spec.brokerProperties).toHaveLength(1);
-    expect(newState.cr.spec.brokerProperties).toContain(
+    expect(newState.cr?.spec?.connectors).toHaveLength(1);
+    expect(newState.cr?.spec?.connectors?.[0].name).toBe('connectors0');
+    expect(newState.cr?.spec?.connectors?.[0].port).toBe(5555);
+    expect(newState.cr?.spec?.connectors?.[0].host === 'localhost');
+    expect(newState.cr?.spec?.brokerProperties).toHaveLength(1);
+    expect(newState.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.connectors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -42,7 +42,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.decrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 0
-    expect(newState.cr.spec.deploymentPlan.size).toBe(0);
+    expect(newState.cr?.spec?.deploymentPlan?.size).toBe(0);
     // set the number of replicas to 10 before decrementing so that the total
     // number should be 9
     const newState2 = reducer712(
@@ -54,7 +54,7 @@ describe('test the creation broker reducer', () => {
         operation: ArtemisReducerOperations712.decrementReplicas,
       },
     );
-    expect(newState2.cr.spec.deploymentPlan.size).toBe(9);
+    expect(newState2.cr?.spec?.deploymentPlan?.size).toBe(9);
   });
 
   it('tests that the deployment replicas value cannot be decremented below 0', () => {
@@ -63,7 +63,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.decrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 0
-    expect(newState.cr.spec.deploymentPlan.size).toBe(0);
+    expect(newState.cr?.spec?.deploymentPlan?.size).toBe(0);
     // Set the number of replicas to -1 and verify that the deployment replicas value cannot be decremented below 0.
     // The number should be set to 0.
     const newState2 = reducer712(
@@ -75,7 +75,7 @@ describe('test the creation broker reducer', () => {
         operation: ArtemisReducerOperations712.decrementReplicas,
       },
     );
-    expect(newState2.cr.spec.deploymentPlan.size).toBe(0);
+    expect(newState2.cr?.spec?.deploymentPlan?.size).toBe(0);
   });
 
   it('test deleteAcceptor', () => {
@@ -87,8 +87,8 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.deleteAcceptor,
       payload: 'acceptors0',
     });
-    expect(newState2.cr.spec.acceptors).toHaveLength(0);
-    expect(newState2.cr.spec.brokerProperties).not.toContain(
+    expect(newState2.cr?.spec?.acceptors).toHaveLength(0);
+    expect(newState2.cr?.spec?.brokerProperties).not.toContain(
       'acceptorConfigurations.acceptors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -102,8 +102,8 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.deleteConnector,
       payload: 'connectors0',
     });
-    expect(newState2.cr.spec.connectors).toHaveLength(0);
-    expect(newState2.cr.spec.brokerProperties).not.toContain(
+    expect(newState2.cr?.spec?.connectors).toHaveLength(0);
+    expect(newState2.cr?.spec?.brokerProperties).not.toContain(
       'connectorConfigurations.connectors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -114,7 +114,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.incrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 1
-    expect(newState.cr.spec.deploymentPlan.size).toBe(2);
+    expect(newState.cr?.spec?.deploymentPlan?.size).toBe(2);
   });
 
   it('test incrementReplicas', () => {
@@ -123,7 +123,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.incrementReplicas,
     });
     // default size is 1 decrementing should result of a size of 1
-    expect(newState.cr.spec.deploymentPlan.size).toBe(2);
+    expect(newState.cr?.spec?.deploymentPlan?.size).toBe(2);
   });
 
   it('test setAcceptorBindToAllInterfaces', () => {
@@ -131,9 +131,9 @@ describe('test the creation broker reducer', () => {
     const stateWith1Acceptor = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(stateWith1Acceptor.cr.spec.acceptors[0].bindToAllInterfaces).toBe(
-      undefined,
-    );
+    expect(
+      stateWith1Acceptor.cr?.spec?.acceptors?.[0].bindToAllInterfaces,
+    ).toBe(undefined);
     const newState2 = reducer712(stateWith1Acceptor, {
       operation: ArtemisReducerOperations712.setAcceptorBindToAllInterfaces,
       payload: {
@@ -141,7 +141,7 @@ describe('test the creation broker reducer', () => {
         bindToAllInterfaces: true,
       },
     });
-    expect(newState2.cr.spec.acceptors[0].bindToAllInterfaces).toBe(true);
+    expect(newState2.cr?.spec?.acceptors?.[0].bindToAllInterfaces).toBe(true);
     const newState3 = reducer712(stateWith1Acceptor, {
       operation: ArtemisReducerOperations712.setAcceptorBindToAllInterfaces,
       payload: {
@@ -149,7 +149,7 @@ describe('test the creation broker reducer', () => {
         bindToAllInterfaces: false,
       },
     });
-    expect(newState3.cr.spec.acceptors[0].bindToAllInterfaces).toBe(false);
+    expect(newState3.cr?.spec?.acceptors?.[0].bindToAllInterfaces).toBe(false);
   });
 
   it('test setAcceptorName', () => {
@@ -164,8 +164,8 @@ describe('test the creation broker reducer', () => {
         newName: 'superName',
       },
     });
-    expect(newState2.cr.spec.acceptors[0].name).toBe('superName');
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.acceptors?.[0].name).toBe('superName');
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.superName.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -185,8 +185,8 @@ describe('test the creation broker reducer', () => {
         newName: 'acceptors0',
       },
     });
-    expect(newState3.cr.spec.acceptors[0].name).toBe('acceptors0');
-    expect(newState3.cr.spec.acceptors[1].name).toBe('acceptors1');
+    expect(newState3.cr?.spec?.acceptors?.[0].name).toBe('acceptors0');
+    expect(newState3.cr?.spec?.acceptors?.[1].name).toBe('acceptors1');
   });
 
   it('test setAcceptorOtherParams', () => {
@@ -204,10 +204,10 @@ describe('test the creation broker reducer', () => {
         ]),
       },
     });
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.params.aKey=aValue',
     );
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.params.bKey=bValue',
     );
     const newState3 = reducer712(newState2, {
@@ -217,10 +217,10 @@ describe('test the creation broker reducer', () => {
         otherParams: new Map<string, string>([['aKey', 'aValue']]),
       },
     });
-    expect(newState3.cr.spec.brokerProperties).toContain(
+    expect(newState3.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.params.aKey=aValue',
     );
-    expect(newState3.cr.spec.brokerProperties).not.toContain(
+    expect(newState3.cr?.spec?.brokerProperties).not.toContain(
       'acceptorConfigurations.acceptors0.params.bKey=bValue',
     );
   });
@@ -232,19 +232,19 @@ describe('test the creation broker reducer', () => {
     let newState = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newState.cr.spec.acceptors[0].port).toBe(5555);
+    expect(newState.cr?.spec?.acceptors?.[0].port).toBe(5555);
 
     // Add a second acceptor
     newState = reducer712(newState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newState.cr.spec.acceptors[1].port).toBe(5556);
+    expect(newState.cr?.spec?.acceptors?.[1].port).toBe(5556);
 
     // Add a third acceptor
     newState = reducer712(newState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newState.cr.spec.acceptors[2].port).toBe(5557);
+    expect(newState.cr?.spec?.acceptors?.[2].port).toBe(5557);
   });
 
   it('test setAcceptorPort', () => {
@@ -259,7 +259,7 @@ describe('test the creation broker reducer', () => {
         port: 6666,
       },
     });
-    expect(newState2.cr.spec.acceptors[0].port).toBe(6666);
+    expect(newState2.cr?.spec?.acceptors?.[0].port).toBe(6666);
   });
 
   it('should increments next acceptor port based on manually set port value', () => {
@@ -274,12 +274,12 @@ describe('test the creation broker reducer', () => {
         port: 6666,
       },
     });
-    expect(newState2.cr.spec.acceptors[0].port).toBe(6666);
+    expect(newState2.cr?.spec?.acceptors?.[0].port).toBe(6666);
 
     newState2 = reducer712(newState2, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newState2.cr.spec.acceptors[1].port).toBe(6667);
+    expect(newState2.cr?.spec?.acceptors?.[1].port).toBe(6667);
   });
 
   it('test setAcceptorProtocols', () => {
@@ -294,7 +294,7 @@ describe('test the creation broker reducer', () => {
         protocols: 'ALL,SOMETHING',
       },
     });
-    expect(newState2.cr.spec.acceptors[0].protocols).toBe('ALL,SOMETHING');
+    expect(newState2.cr?.spec?.acceptors?.[0].protocols).toBe('ALL,SOMETHING');
   });
 
   it('test setAcceptorSSLEnabled', () => {
@@ -309,7 +309,7 @@ describe('test the creation broker reducer', () => {
         sslEnabled: true,
       },
     });
-    expect(newState2.cr.spec.acceptors[0].sslEnabled).toBe(true);
+    expect(newState2.cr?.spec?.acceptors?.[0].sslEnabled).toBe(true);
   });
 
   it('test setAcceptorSecret', () => {
@@ -325,7 +325,7 @@ describe('test the creation broker reducer', () => {
         secret: 'toto',
       },
     });
-    expect(newState2.cr.spec.acceptors[0].sslSecret).toBe('toto');
+    expect(newState2.cr?.spec?.acceptors?.[0].sslSecret).toBe('toto');
     const newState3 = reducer712(newState2, {
       operation: ArtemisReducerOperations712.setAcceptorSecret,
       payload: {
@@ -334,7 +334,7 @@ describe('test the creation broker reducer', () => {
         secret: 'toto',
       },
     });
-    expect(newState3.cr.spec.acceptors[0].trustSecret).toBe('toto');
+    expect(newState3.cr?.spec?.acceptors?.[0].trustSecret).toBe('toto');
   });
 
   it('test setBrokerName', () => {
@@ -343,7 +343,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setBrokerName,
       payload: 'newName',
     });
-    expect(newState.cr.metadata.name).toBe('newName');
+    expect(newState.cr?.metadata?.name).toBe('newName');
   });
 
   // enchaine avec le lwoercase
@@ -352,9 +352,9 @@ describe('test the creation broker reducer', () => {
     const stateWith1Connector = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(stateWith1Connector.cr.spec.connectors[0].bindToAllInterfaces).toBe(
-      undefined,
-    );
+    expect(
+      stateWith1Connector.cr?.spec?.connectors?.[0].bindToAllInterfaces,
+    ).toBe(undefined);
     const newState2 = reducer712(stateWith1Connector, {
       operation: ArtemisReducerOperations712.setConnectorBindToAllInterfaces,
       payload: {
@@ -362,7 +362,7 @@ describe('test the creation broker reducer', () => {
         bindToAllInterfaces: true,
       },
     });
-    expect(newState2.cr.spec.connectors[0].bindToAllInterfaces).toBe(true);
+    expect(newState2.cr?.spec?.connectors?.[0].bindToAllInterfaces).toBe(true);
     const newState3 = reducer712(stateWith1Connector, {
       operation: ArtemisReducerOperations712.setConnectorBindToAllInterfaces,
       payload: {
@@ -370,7 +370,7 @@ describe('test the creation broker reducer', () => {
         bindToAllInterfaces: false,
       },
     });
-    expect(newState3.cr.spec.connectors[0].bindToAllInterfaces).toBe(false);
+    expect(newState3.cr?.spec?.connectors?.[0].bindToAllInterfaces).toBe(false);
   });
 
   it('test setConnectorHost', () => {
@@ -385,7 +385,7 @@ describe('test the creation broker reducer', () => {
         host: 'superHost',
       },
     });
-    expect(newState2.cr.spec.connectors[0].host).toBe('superHost');
+    expect(newState2.cr?.spec?.connectors?.[0].host).toBe('superHost');
   });
 
   it('test setConnectorName', () => {
@@ -400,8 +400,8 @@ describe('test the creation broker reducer', () => {
         newName: 'superName',
       },
     });
-    expect(newState2.cr.spec.connectors[0].name).toBe('superName');
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.connectors?.[0].name).toBe('superName');
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.superName.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -421,8 +421,8 @@ describe('test the creation broker reducer', () => {
         newName: 'connectors0',
       },
     });
-    expect(newState3.cr.spec.connectors[0].name).toBe('connectors0');
-    expect(newState3.cr.spec.connectors[1].name).toBe('connectors1');
+    expect(newState3.cr?.spec?.connectors?.[0].name).toBe('connectors0');
+    expect(newState3.cr?.spec?.connectors?.[1].name).toBe('connectors1');
   });
 
   it('test setConnectorOtherParams', () => {
@@ -440,10 +440,10 @@ describe('test the creation broker reducer', () => {
         ]),
       },
     });
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.connectors0.params.aKey=aValue',
     );
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.connectors0.params.bKey=bValue',
     );
     const newState3 = reducer712(newState2, {
@@ -453,10 +453,10 @@ describe('test the creation broker reducer', () => {
         otherParams: new Map<string, string>([['aKey', 'aValue']]),
       },
     });
-    expect(newState3.cr.spec.brokerProperties).toContain(
+    expect(newState3.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.connectors0.params.aKey=aValue',
     );
-    expect(newState3.cr.spec.brokerProperties).not.toContain(
+    expect(newState3.cr?.spec?.brokerProperties).not.toContain(
       'connectorConfigurations.connectors0.params.bKey=bValue',
     );
   });
@@ -468,19 +468,19 @@ describe('test the creation broker reducer', () => {
     let newState = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newState.cr.spec.connectors[0].port).toBe(5555);
+    expect(newState.cr?.spec?.connectors?.[0].port).toBe(5555);
 
     // Add a second connector
     newState = reducer712(newState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newState.cr.spec.connectors[1].port).toBe(5556);
+    expect(newState.cr?.spec?.connectors?.[1].port).toBe(5556);
 
     // Add a third connector
     newState = reducer712(newState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newState.cr.spec.connectors[2].port).toBe(5557);
+    expect(newState.cr?.spec?.connectors?.[2].port).toBe(5557);
   });
 
   it('test setConnectorPort', () => {
@@ -495,7 +495,7 @@ describe('test the creation broker reducer', () => {
         port: 6666,
       },
     });
-    expect(newState2.cr.spec.connectors[0].port).toBe(6666);
+    expect(newState2.cr?.spec?.connectors?.[0].port).toBe(6666);
   });
 
   it('should increments next connector port based on manually set port value', () => {
@@ -510,12 +510,12 @@ describe('test the creation broker reducer', () => {
         port: 6666,
       },
     });
-    expect(newState2.cr.spec.connectors[0].port).toBe(6666);
+    expect(newState2.cr?.spec?.connectors?.[0].port).toBe(6666);
 
     newState2 = reducer712(newState2, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newState2.cr.spec.connectors[1].port).toBe(6667);
+    expect(newState2.cr?.spec?.connectors?.[1].port).toBe(6667);
   });
 
   it('test unique port allocation by combining both new added acceptors/connectors and verify correct port incrementation after manual port modification', () => {
@@ -524,13 +524,13 @@ describe('test the creation broker reducer', () => {
     let newStateWithAcceptor = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newStateWithAcceptor.cr.spec.acceptors[0].port).toBe(5555);
+    expect(newStateWithAcceptor.cr?.spec?.acceptors?.[0].port).toBe(5555);
 
     //Add second acceptor
     newStateWithAcceptor = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newStateWithAcceptor.cr.spec.acceptors[1].port).toBe(5556);
+    expect(newStateWithAcceptor.cr?.spec?.acceptors?.[1].port).toBe(5556);
 
     // Manually change the port of the second acceptor to 5557
     newStateWithAcceptor = reducer712(newStateWithAcceptor, {
@@ -540,25 +540,25 @@ describe('test the creation broker reducer', () => {
         port: 5557,
       },
     });
-    expect(newStateWithAcceptor.cr.spec.acceptors[1].port).toBe(5557);
+    expect(newStateWithAcceptor.cr?.spec?.acceptors?.[1].port).toBe(5557);
 
     //Add third acceptor
     newStateWithAcceptor = reducer712(newStateWithAcceptor, {
       operation: ArtemisReducerOperations712.addAcceptor,
     });
-    expect(newStateWithAcceptor.cr.spec.acceptors[2].port).toBe(5558);
+    expect(newStateWithAcceptor.cr?.spec?.acceptors?.[2].port).toBe(5558);
 
     //Add first connector
     let newStateWithConnector = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newStateWithConnector.cr.spec.connectors[0].port).toBe(5555);
+    expect(newStateWithConnector.cr?.spec?.connectors?.[0].port).toBe(5555);
 
     //Add second connector
     newStateWithConnector = reducer712(initialState, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5556);
+    expect(newStateWithConnector.cr?.spec?.connectors?.[1].port).toBe(5556);
 
     // Manually change the port of the second connector to 5557
     newStateWithConnector = reducer712(newStateWithConnector, {
@@ -568,13 +568,13 @@ describe('test the creation broker reducer', () => {
         port: 5557,
       },
     });
-    expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5557);
+    expect(newStateWithConnector.cr?.spec?.connectors?.[1].port).toBe(5557);
 
     //Add third connector
     newStateWithConnector = reducer712(newStateWithConnector, {
       operation: ArtemisReducerOperations712.addConnector,
     });
-    expect(newStateWithConnector.cr.spec.connectors[2].port).toBe(5558);
+    expect(newStateWithConnector.cr?.spec?.connectors?.[2].port).toBe(5558);
   });
 
   it('test setConnectorProtocols', () => {
@@ -589,7 +589,7 @@ describe('test the creation broker reducer', () => {
         protocols: 'ALL,SOMETHING',
       },
     });
-    expect(newState2.cr.spec.connectors[0].protocols).toBe('ALL,SOMETHING');
+    expect(newState2.cr?.spec?.connectors?.[0].protocols).toBe('ALL,SOMETHING');
   });
 
   it('test setConnectorSSLEnabled', () => {
@@ -604,7 +604,7 @@ describe('test the creation broker reducer', () => {
         sslEnabled: true,
       },
     });
-    expect(newState2.cr.spec.connectors[0].sslEnabled).toBe(true);
+    expect(newState2.cr?.spec?.connectors?.[0].sslEnabled).toBe(true);
   });
 
   it('test setConnectorSecret', () => {
@@ -620,7 +620,7 @@ describe('test the creation broker reducer', () => {
         secret: 'toto',
       },
     });
-    expect(newState2.cr.spec.connectors[0].sslSecret).toBe('toto');
+    expect(newState2.cr?.spec?.connectors?.[0].sslSecret).toBe('toto');
     const newState3 = reducer712(newState2, {
       operation: ArtemisReducerOperations712.setConnectorSecret,
       payload: {
@@ -629,7 +629,7 @@ describe('test the creation broker reducer', () => {
         secret: 'toto',
       },
     });
-    expect(newState3.cr.spec.connectors[0].trustSecret).toBe('toto');
+    expect(newState3.cr?.spec?.connectors?.[0].trustSecret).toBe('toto');
   });
 
   it('test setConsoleCredentials', () => {
@@ -641,8 +641,8 @@ describe('test the creation broker reducer', () => {
         adminPassword: 'thing',
       },
     });
-    expect(newState.cr.spec.adminUser).toBe('some');
-    expect(newState.cr.spec.adminPassword).toBe('thing');
+    expect(newState.cr?.spec?.adminUser).toBe('some');
+    expect(newState.cr?.spec?.adminPassword).toBe('thing');
   });
 
   it('test setConsoleExpose', () => {
@@ -651,7 +651,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setConsoleExpose,
       payload: true,
     });
-    expect(newState.cr.spec.console.expose).toBe(true);
+    expect(newState.cr?.spec?.console?.expose).toBe(true);
   });
 
   it('test setConsoleExposeMode', () => {
@@ -660,7 +660,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setConsoleExposeMode,
       payload: ExposeMode.route,
     });
-    expect(newState.cr.spec.console.exposeMode).toBe(ExposeMode.route);
+    expect(newState.cr?.spec?.console?.exposeMode).toBe(ExposeMode.route);
   });
 
   it('test setConsoleExposeMode', () => {
@@ -669,7 +669,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setConsoleExposeMode,
       payload: ExposeMode.ingress,
     });
-    expect(newState.cr.spec.console.exposeMode).toBe(ExposeMode.ingress);
+    expect(newState.cr?.spec?.console?.exposeMode).toBe(ExposeMode.ingress);
   });
 
   it('test setConsoleSSLEnabled', () => {
@@ -678,7 +678,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setConsoleSSLEnabled,
       payload: true,
     });
-    expect(newState.cr.spec.console.sslEnabled).toBe(true);
+    expect(newState.cr?.spec?.console?.sslEnabled).toBe(true);
   });
 
   it('test setConsoleSecret', () => {
@@ -691,7 +691,7 @@ describe('test the creation broker reducer', () => {
         secret: 'toto',
       },
     });
-    expect(newState.cr.spec.console.trustSecret).toBe('toto');
+    expect(newState.cr?.spec?.console?.trustSecret).toBe('toto');
   });
 
   it('test setNamespace', () => {
@@ -700,7 +700,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setNamespace,
       payload: 'newNamespace',
     });
-    expect(newState.cr.metadata.namespace).toBe('newNamespace');
+    expect(newState.cr?.metadata?.namespace).toBe('newNamespace');
   });
 
   it('test replicas setReplicasNumber', () => {
@@ -709,7 +709,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setReplicasNumber,
       payload: 10,
     });
-    expect(newState.cr.spec.deploymentPlan.size).toBe(10);
+    expect(newState.cr?.spec?.deploymentPlan?.size).toBe(10);
   });
 
   it('test updateAcceptorFactoryClass', () => {
@@ -724,7 +724,7 @@ describe('test the creation broker reducer', () => {
         class: 'invm',
       },
     });
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory',
     );
     const newState3 = reducer712(newState2, {
@@ -734,7 +734,7 @@ describe('test the creation broker reducer', () => {
         class: 'netty',
       },
     });
-    expect(newState3.cr.spec.brokerProperties).toContain(
+    expect(newState3.cr?.spec?.brokerProperties).toContain(
       'acceptorConfigurations.acceptors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -751,7 +751,7 @@ describe('test the creation broker reducer', () => {
         class: 'invm',
       },
     });
-    expect(newState2.cr.spec.brokerProperties).toContain(
+    expect(newState2.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.connectors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory',
     );
     const newState3 = reducer712(newState2, {
@@ -761,7 +761,7 @@ describe('test the creation broker reducer', () => {
         class: 'netty',
       },
     });
-    expect(newState3.cr.spec.brokerProperties).toContain(
+    expect(newState3.cr?.spec?.brokerProperties).toContain(
       'connectorConfigurations.connectors0.factoryClassName=org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory',
     );
   });
@@ -782,25 +782,31 @@ describe('test the creation broker reducer', () => {
         issuer: 'someIssuer',
       },
     });
-    expect(stateWithPEM.cr.spec.acceptors[0].sslEnabled).toBe(true);
-    expect(stateWithPEM.cr.spec.acceptors[0].exposeMode).toBe(
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.length).toBeGreaterThan(0);
+
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].sslEnabled).toBe(true);
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].exposeMode).toBe(
       ExposeMode.ingress,
     );
-    expect(stateWithPEM.cr.spec.acceptors[0].ingressHost).toBe(
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].ingressHost).toBe(
       'ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)',
     );
-    expect(stateWithPEM.cr.spec.acceptors[0].sslSecret).toBe(
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].sslSecret).toBe(
       'ex-aao-acceptors0-0-svc-ing-ptls',
     );
-    expect(stateWithPEM.cr.spec.resourceTemplates).toHaveLength(1);
-    expect(stateWithPEM.cr.spec.resourceTemplates[0].selector.name).toBe(
+    expect(stateWithPEM.cr?.spec?.resourceTemplates).toHaveLength(1);
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.[0].selector).not.toBe(
+      undefined,
+    );
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.[0]?.selector?.name).toBe(
       'ex-aao' + '-' + 'acceptors0' + '-0-svc-ing',
     );
-    expect(stateWithPEM.cr.spec.resourceTemplates[0].selector.name).toBe(
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.[0]?.selector?.name).toBe(
       'ex-aao' + '-' + 'acceptors0' + '-0-svc-ing',
     );
     expect(
-      stateWithPEM.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+      stateWithPEM.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe(
       'ing.' +
         'acceptors0' +
@@ -816,18 +822,24 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setBrokerName,
       payload: 'bro',
     });
-    expect(updatedBrokerName.cr.spec.acceptors[0].sslSecret).toBe(
+
+    expect(updatedBrokerName.cr?.spec?.resourceTemplates?.[0]).not.toBe(
+      undefined,
+    );
+
+    expect(updatedBrokerName.cr?.spec?.acceptors?.[0].sslSecret).toBe(
       'bro-acceptors0-0-svc-ing-ptls',
     );
-    expect(updatedBrokerName.cr.spec.resourceTemplates).toHaveLength(1);
-    expect(updatedBrokerName.cr.spec.resourceTemplates[0].selector.name).toBe(
-      'bro' + '-' + 'acceptors0' + '-0-svc-ing',
-    );
-    expect(updatedBrokerName.cr.spec.resourceTemplates[0].selector.name).toBe(
-      'bro' + '-' + 'acceptors0' + '-0-svc-ing',
-    );
+    expect(updatedBrokerName.cr?.spec?.resourceTemplates).toHaveLength(1);
     expect(
-      updatedBrokerName.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+      updatedBrokerName.cr?.spec?.resourceTemplates?.[0]?.selector?.name,
+    ).toBe('bro' + '-' + 'acceptors0' + '-0-svc-ing');
+    expect(
+      updatedBrokerName.cr?.spec?.resourceTemplates?.[0]?.selector?.name,
+    ).toBe('bro' + '-' + 'acceptors0' + '-0-svc-ing');
+    expect(
+      updatedBrokerName.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe(
       'ing.' +
         'acceptors0' +
@@ -843,9 +855,10 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setNamespace,
       payload: 'space',
     });
-    expect(updatedNamespace.cr.spec.resourceTemplates).toHaveLength(1);
+    expect(updatedBrokerName.cr?.spec?.resourceTemplates).toHaveLength(1);
     expect(
-      updatedNamespace.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+      updatedBrokerName.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe(
       'ing.' +
         'acceptors0' +
@@ -861,9 +874,11 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setIngressDomain,
       payload: 'tttt.com',
     });
-    expect(updatedDomain.cr.spec.resourceTemplates).toHaveLength(1);
+
+    expect(updatedDomain.cr?.spec?.resourceTemplates).toHaveLength(1);
     expect(
-      updatedDomain.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+      updatedDomain.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe(
       'ing.' + 'acceptors0' + '.' + 'bro' + '-0.' + 'space' + '.' + 'tttt.com',
     );
@@ -875,26 +890,29 @@ describe('test the creation broker reducer', () => {
         newName: 'bob',
       },
     });
-    expect(updatedAcceptorName.cr.spec.acceptors[0].sslEnabled).toBe(true);
-    expect(updatedAcceptorName.cr.spec.acceptors[0].exposeMode).toBe(
+    expect(updatedAcceptorName.cr?.spec?.acceptors?.[0].sslEnabled).toBe(true);
+    expect(updatedAcceptorName.cr?.spec?.acceptors?.[0].exposeMode).toBe(
       ExposeMode.ingress,
     );
-    expect(updatedAcceptorName.cr.spec.acceptors[0].ingressHost).toBe(
+    expect(updatedAcceptorName.cr?.spec?.acceptors?.[0].ingressHost).toBe(
       'ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)',
     );
-    expect(updatedAcceptorName.cr.spec.acceptors[0].sslSecret).toBe(
+    expect(updatedAcceptorName.cr?.spec?.acceptors?.[0].sslSecret).toBe(
       'bro-bob-0-svc-ing-ptls',
     );
-    expect(updatedAcceptorName.cr.spec.resourceTemplates).toHaveLength(1);
-    expect(updatedAcceptorName.cr.spec.resourceTemplates[0].selector.name).toBe(
-      'bro' + '-' + 'bob' + '-0-svc-ing',
+    expect(updatedAcceptorName.cr?.spec?.resourceTemplates?.[0]).not.toBe(
+      undefined,
     );
-    expect(updatedAcceptorName.cr.spec.resourceTemplates[0].selector.name).toBe(
-      'bro' + '-' + 'bob' + '-0-svc-ing',
-    );
+    expect(updatedAcceptorName.cr?.spec?.resourceTemplates).toHaveLength(1);
     expect(
-      updatedAcceptorName.cr.spec.resourceTemplates[0].patch.spec.tls[0]
-        .hosts[0],
+      updatedAcceptorName.cr?.spec?.resourceTemplates?.[0]?.selector?.name,
+    ).toBe('bro' + '-' + 'bob' + '-0-svc-ing');
+    expect(
+      updatedAcceptorName.cr?.spec?.resourceTemplates?.[0]?.selector?.name,
+    ).toBe('bro' + '-' + 'bob' + '-0-svc-ing');
+    expect(
+      updatedAcceptorName.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe('ing.' + 'bob' + '.' + 'bro' + '-0.' + 'space' + '.' + 'tttt.com');
     // setting the trust secret doesn't change the values
     const withTrustSecret = reducer712(updatedDomain, {
@@ -905,25 +923,32 @@ describe('test the creation broker reducer', () => {
         secret: 'toto',
       },
     });
-    expect(withTrustSecret.cr.spec.acceptors[0].sslEnabled).toBe(true);
-    expect(withTrustSecret.cr.spec.acceptors[0].exposeMode).toBe(
+    expect(withTrustSecret.cr?.spec?.acceptors?.[0].sslEnabled).toBe(true);
+    expect(withTrustSecret.cr?.spec?.acceptors?.[0].exposeMode).toBe(
       ExposeMode.ingress,
     );
-    expect(withTrustSecret.cr.spec.acceptors[0].ingressHost).toBe(
+    expect(withTrustSecret.cr?.spec?.acceptors?.[0].ingressHost).toBe(
       'ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)',
     );
-    expect(withTrustSecret.cr.spec.acceptors[0].sslSecret).toBe(
+    expect(withTrustSecret.cr?.spec?.acceptors?.[0].sslSecret).toBe(
       'bro-bob-0-svc-ing-ptls',
     );
-    expect(withTrustSecret.cr.spec.resourceTemplates).toHaveLength(1);
-    expect(withTrustSecret.cr.spec.resourceTemplates[0].selector.name).toBe(
-      'bro' + '-' + 'bob' + '-0-svc-ing',
+    expect(withTrustSecret.cr?.spec?.resourceTemplates?.[0]).not.toBe(
+      undefined,
     );
-    expect(withTrustSecret.cr.spec.resourceTemplates[0].selector.name).toBe(
-      'bro' + '-' + 'bob' + '-0-svc-ing',
+    expect(withTrustSecret.cr?.spec?.resourceTemplates).toHaveLength(1);
+    expect(withTrustSecret.cr?.spec?.resourceTemplates?.[0].selector).not.toBe(
+      undefined,
     );
     expect(
-      withTrustSecret.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+      withTrustSecret.cr?.spec?.resourceTemplates?.[0]?.selector?.name,
+    ).toBe('bro' + '-' + 'bob' + '-0-svc-ing');
+    expect(
+      withTrustSecret.cr?.spec?.resourceTemplates?.[0]?.selector?.name,
+    ).toBe('bro' + '-' + 'bob' + '-0-svc-ing');
+    expect(
+      withTrustSecret.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe('ing.' + 'bob' + '.' + 'bro' + '-0.' + 'space' + '.' + 'tttt.com');
   });
 
@@ -943,25 +968,30 @@ describe('test the creation broker reducer', () => {
         issuer: 'someIssuer',
       },
     });
-    expect(stateWithPEM.cr.spec.acceptors[0].sslEnabled).toBe(true);
-    expect(stateWithPEM.cr.spec.acceptors[0].exposeMode).toBe(
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].sslEnabled).toBe(true);
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].exposeMode).toBe(
       ExposeMode.ingress,
     );
-    expect(stateWithPEM.cr.spec.acceptors[0].ingressHost).toBe(
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].ingressHost).toBe(
       'ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)',
     );
-    expect(stateWithPEM.cr.spec.acceptors[0].sslSecret).toBe(
+    expect(stateWithPEM.cr?.spec?.acceptors?.[0].sslSecret).toBe(
       'ex-aao-acceptors0-0-svc-ing-ptls',
     );
-    expect(stateWithPEM.cr.spec.resourceTemplates).toHaveLength(1);
-    expect(stateWithPEM.cr.spec.resourceTemplates[0].selector.name).toBe(
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.length).toBeGreaterThan(0);
+    expect(stateWithPEM.cr?.spec?.resourceTemplates).toHaveLength(1);
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.[0].selector).not.toBe(
+      undefined,
+    );
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.[0]?.selector?.name).toBe(
       'ex-aao' + '-' + 'acceptors0' + '-0-svc-ing',
     );
-    expect(stateWithPEM.cr.spec.resourceTemplates[0].selector.name).toBe(
+    expect(stateWithPEM.cr?.spec?.resourceTemplates?.[0]?.selector?.name).toBe(
       'ex-aao' + '-' + 'acceptors0' + '-0-svc-ing',
     );
     expect(
-      stateWithPEM.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts[0],
+      stateWithPEM.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe(
       'ing.' +
         'acceptors0' +
@@ -975,9 +1005,12 @@ describe('test the creation broker reducer', () => {
     const stateWith2Replicas = reducer712(stateWithPEM, {
       operation: ArtemisReducerOperations712.incrementReplicas,
     });
+    expect(stateWith2Replicas.cr?.spec?.resourceTemplates?.[0]).not.toBe(
+      undefined,
+    );
     expect(
-      stateWith2Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0]
-        .hosts[0],
+      stateWith2Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[0],
     ).toBe(
       'ing.' +
         'acceptors0' +
@@ -989,8 +1022,8 @@ describe('test the creation broker reducer', () => {
         'apps-crc.testing',
     );
     expect(
-      stateWith2Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0]
-        .hosts[1],
+      stateWith2Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts?.[1],
     ).toBe(
       'ing.' +
         'acceptors0' +
@@ -1002,7 +1035,8 @@ describe('test the creation broker reducer', () => {
         'apps-crc.testing',
     );
     expect(
-      stateWith2Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts,
+      stateWith2Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts,
     ).toHaveLength(2);
 
     const newNumber = 10;
@@ -1010,13 +1044,17 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.setReplicasNumber,
       payload: newNumber,
     });
+    expect(stateWith10Replicas.cr?.spec?.resourceTemplates?.[0]).not.toBe(
+      undefined,
+    );
     expect(
-      stateWith10Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts,
+      stateWith10Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts,
     ).toHaveLength(newNumber);
     for (let i = 0; i < newNumber; i++) {
       expect(
-        stateWith10Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0]
-          .hosts[i],
+        stateWith10Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec
+          ?.tls?.[0]?.hosts?.[i],
       ).toBe(
         'ing.' +
           'acceptors0' +
@@ -1033,13 +1071,17 @@ describe('test the creation broker reducer', () => {
     const stateWith9Replicas = reducer712(stateWith10Replicas, {
       operation: ArtemisReducerOperations712.decrementReplicas,
     });
+    expect(stateWith9Replicas.cr?.spec?.resourceTemplates?.[0]).not.toBe(
+      undefined,
+    );
     expect(
-      stateWith9Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts,
+      stateWith9Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec?.tls?.[0]
+        ?.hosts,
     ).toHaveLength(9);
     for (let i = 0; i < 9; i++) {
       expect(
-        stateWith10Replicas.cr.spec.resourceTemplates[0].patch.spec.tls[0]
-          .hosts[i],
+        stateWith9Replicas.cr?.spec?.resourceTemplates?.[0].patch?.spec
+          ?.tls?.[0]?.hosts?.[i],
       ).toBe(
         'ing.' +
           'acceptors0' +
@@ -1071,9 +1113,13 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations712.deletePEMGenerationForAcceptor,
       payload: 'acceptors0',
     });
-    expect(stateWithDeletedPEM.cr.spec.acceptors[0].sslEnabled).toBe(undefined);
-    expect(stateWithDeletedPEM.cr.spec.acceptors[0].sslSecret).toBe(undefined);
-    expect(stateWithDeletedPEM.cr.spec.resourceTemplates).toBe(undefined);
+    expect(stateWithDeletedPEM.cr?.spec?.acceptors?.[0].sslEnabled).toBe(
+      undefined,
+    );
+    expect(stateWithDeletedPEM.cr?.spec?.acceptors?.[0].sslSecret).toBe(
+      undefined,
+    );
+    expect(stateWithDeletedPEM.cr?.spec?.resourceTemplates).toBe(undefined);
   });
 
   it('test setAcceptorExposeMode,', () => {
@@ -1088,7 +1134,7 @@ describe('test the creation broker reducer', () => {
         exposeMode: ExposeMode.ingress,
       },
     });
-    expect(stateExposeModeIngress.cr.spec.acceptors[0].exposeMode).toBe(
+    expect(stateExposeModeIngress.cr?.spec?.acceptors?.[0].exposeMode).toBe(
       ExposeMode.ingress,
     );
   });
@@ -1105,7 +1151,7 @@ describe('test the creation broker reducer', () => {
         ingressHost: 'tuytutu',
       },
     });
-    expect(stateExposeModeIngress.cr.spec.acceptors[0].ingressHost).toBe(
+    expect(stateExposeModeIngress.cr?.spec?.acceptors?.[0].ingressHost).toBe(
       'tuytutu',
     );
   });
@@ -1122,6 +1168,6 @@ describe('test the creation broker reducer', () => {
         isExposed: true,
       },
     });
-    expect(stateExposeModeIngress.cr.spec.acceptors[0].expose).toBe(true);
+    expect(stateExposeModeIngress.cr?.spec?.acceptors?.[0].expose).toBe(true);
   });
 });

--- a/src/reducers/7.12/reducer.ts
+++ b/src/reducers/7.12/reducer.ts
@@ -524,79 +524,116 @@ export const reducer712: React.Reducer<
   FormState712,
   ArtemisReducerActions712
 > = (prevFormState, action) => {
-  const formState = { ...prevFormState };
+  const formState: FormState712 = { ...prevFormState };
+  if (!formState.cr) throw new Error('cr should not be undefined');
   // set the individual fields
   switch (action.operation) {
-    case ArtemisReducerOperations712.updateAnnotationIssuer:
+    case ArtemisReducerOperations712.updateAnnotationIssuer: {
       updateAnnotationIssuer(
         formState.cr,
         action.payload.acceptorName,
         action.payload.newIssuer,
       );
       break;
-    case ArtemisReducerOperations712.setAcceptorIngressHost:
-      getAcceptor(formState.cr, action.payload.name).ingressHost =
-        action.payload.ingressHost;
-      break;
-    case ArtemisReducerOperations712.setAcceptorExposeMode:
-      if (action.payload) {
-        getAcceptor(formState.cr, action.payload.name).exposeMode =
-          action.payload.exposeMode;
-      } else {
-        delete getAcceptor(formState.cr, action.payload.name).exposeMode;
+    }
+    case ArtemisReducerOperations712.setAcceptorIngressHost: {
+      const acceptor = getAcceptor(formState.cr, action.payload.name);
+      if (acceptor) {
+        acceptor.ingressHost = action.payload.ingressHost;
       }
       break;
-    case ArtemisReducerOperations712.setIsAcceptorExposed:
-      getAcceptor(formState.cr, action.payload.name).expose =
-        action.payload.isExposed;
+    }
+    case ArtemisReducerOperations712.setAcceptorExposeMode: {
+      const acceptor = getAcceptor(formState.cr, action.payload.name);
+      if (acceptor) {
+        if (action.payload) {
+          acceptor.exposeMode = action.payload.exposeMode;
+        } else {
+          delete acceptor.exposeMode;
+        }
+      }
       break;
-    case ArtemisReducerOperations712.setNamespace:
+    }
+    case ArtemisReducerOperations712.setIsAcceptorExposed: {
+      const acceptor = getAcceptor(formState.cr, action.payload.name);
+      if (acceptor) {
+        acceptor.expose = action.payload.isExposed;
+      }
+      break;
+    }
+    case ArtemisReducerOperations712.setNamespace: {
       updateNamespace(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations712.setReplicasNumber:
+    }
+    case ArtemisReducerOperations712.setReplicasNumber: {
       updateDeploymentSize(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations712.incrementReplicas:
+    }
+    case ArtemisReducerOperations712.incrementReplicas: {
+      if (!formState.cr.spec) throw new Error('spec should not be undefined');
+      if (!formState.cr.spec.deploymentPlan) {
+        formState.cr.spec.deploymentPlan = {
+          image: 'placeholder',
+          requireLogin: false,
+          size: 1,
+        };
+      }
       updateDeploymentSize(
         formState.cr,
         formState.cr.spec.deploymentPlan.size + 1,
       );
       break;
-    case ArtemisReducerOperations712.decrementReplicas:
+    }
+    case ArtemisReducerOperations712.decrementReplicas: {
+      if (!formState.cr.spec) throw new Error('spec should not be undefined');
+      if (!formState.cr.spec.deploymentPlan) {
+        formState.cr.spec.deploymentPlan = {
+          image: 'placeholder',
+          requireLogin: false,
+          size: 1,
+        };
+      }
       updateDeploymentSize(
         formState.cr,
         formState.cr.spec.deploymentPlan.size - 1,
       );
       break;
-    case ArtemisReducerOperations712.setBrokerName:
+    }
+    case ArtemisReducerOperations712.setBrokerName: {
       updateBrokerName(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations712.activatePEMGenerationForAcceptor:
+    }
+    case ArtemisReducerOperations712.activatePEMGenerationForAcceptor: {
       activatePEMGenerationForAcceptor(formState.cr, action.payload.acceptor);
-      setIssuerForAcceptor(
-        formState.cr,
-        getAcceptor(formState.cr, action.payload.acceptor),
-        action.payload.issuer,
-      );
+      const acceptor = getAcceptor(formState.cr, action.payload.acceptor);
+      if (acceptor) {
+        setIssuerForAcceptor(formState.cr, acceptor, action.payload.issuer);
+      }
       break;
-    case ArtemisReducerOperations712.deletePEMGenerationForAcceptor:
+    }
+    case ArtemisReducerOperations712.deletePEMGenerationForAcceptor: {
       clearAcceptorCertManagerConfig(formState.cr, action.payload);
       break;
-    case ArtemisReducerOperations712.addAcceptor:
+    }
+    case ArtemisReducerOperations712.addAcceptor: {
       addConfig(formState.cr, ConfigType.acceptors);
       break;
-    case ArtemisReducerOperations712.addConnector:
+    }
+    case ArtemisReducerOperations712.addConnector: {
       addConfig(formState.cr, ConfigType.connectors);
       break;
-    case ArtemisReducerOperations712.deleteAcceptor:
+    }
+    case ArtemisReducerOperations712.deleteAcceptor: {
       // before deleting an acceptor, remove any linked annotations
       deleteCertManagerAnnotation(formState.cr, action.payload);
       deleteConfig(formState.cr, ConfigType.acceptors, action.payload);
       break;
-    case ArtemisReducerOperations712.deleteConnector:
+    }
+    case ArtemisReducerOperations712.deleteConnector: {
       deleteConfig(formState.cr, ConfigType.connectors, action.payload);
       break;
-    case ArtemisReducerOperations712.setAcceptorName:
+    }
+    case ArtemisReducerOperations712.setAcceptorName: {
       renameConfig(
         formState.cr,
         ConfigType.acceptors,
@@ -611,7 +648,8 @@ export const reducer712: React.Reducer<
         action.payload.newName,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorName:
+    }
+    case ArtemisReducerOperations712.setConnectorName: {
       renameConfig(
         formState.cr,
         ConfigType.connectors,
@@ -619,7 +657,8 @@ export const reducer712: React.Reducer<
         action.payload.newName,
       );
       break;
-    case ArtemisReducerOperations712.setAcceptorSecret:
+    }
+    case ArtemisReducerOperations712.setAcceptorSecret: {
       // when the user sets the acceptor secret manually and that secret is not
       // a CA, remove any linked annotations
       if (!action.payload.isCa) {
@@ -642,7 +681,9 @@ export const reducer712: React.Reducer<
         action.payload.isCa,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorSecret:
+    }
+
+    case ArtemisReducerOperations712.setConnectorSecret: {
       updateConfigSecret(
         formState.cr,
         ConfigType.connectors,
@@ -651,7 +692,8 @@ export const reducer712: React.Reducer<
         action.payload.isCa,
       );
       break;
-    case ArtemisReducerOperations712.setConsoleSecret:
+    }
+    case ArtemisReducerOperations712.setConsoleSecret: {
       updateConfigSecret(
         formState.cr,
         ConfigType.console,
@@ -660,23 +702,41 @@ export const reducer712: React.Reducer<
         action.payload.isCa,
       );
       break;
-    case ArtemisReducerOperations712.setConsoleSSLEnabled:
+    }
+    case ArtemisReducerOperations712.setConsoleSSLEnabled: {
+      if (!formState.cr.spec) throw new Error('spec should not be undefined');
+      if (!formState.cr.spec.console) {
+        formState.cr.spec.console = { expose: false };
+      }
       formState.cr.spec.console.sslEnabled = action.payload;
       if (!action.payload) {
         delete formState.cr.spec.console.useClientAuth;
       }
       break;
-    case ArtemisReducerOperations712.setConsoleExposeMode:
+    }
+    case ArtemisReducerOperations712.setConsoleExposeMode: {
+      if (!formState.cr.spec) throw new Error('spec should not be undefined');
+      if (!formState.cr.spec.console) {
+        formState.cr.spec.console = { expose: false };
+      }
       formState.cr.spec.console.exposeMode = action.payload;
       break;
-    case ArtemisReducerOperations712.setConsoleExpose:
+    }
+    case ArtemisReducerOperations712.setConsoleExpose: {
+      if (!formState.cr.spec) throw new Error('spec should not be undefined');
+      if (!formState.cr.spec.console) {
+        formState.cr.spec.console = { expose: false };
+      }
       formState.cr.spec.console.expose = action.payload;
       break;
-    case ArtemisReducerOperations712.setConsoleCredentials:
+    }
+    case ArtemisReducerOperations712.setConsoleCredentials: {
+      if (!formState.cr.spec) throw new Error('spec should not be undefined');
       formState.cr.spec.adminUser = action.payload.adminUser;
       formState.cr.spec.adminPassword = action.payload.adminPassword;
       break;
-    case ArtemisReducerOperations712.setAcceptorPort:
+    }
+    case ArtemisReducerOperations712.setAcceptorPort: {
       updateConfigPort(
         formState.cr,
         ConfigType.acceptors,
@@ -684,7 +744,8 @@ export const reducer712: React.Reducer<
         action.payload.port,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorPort:
+    }
+    case ArtemisReducerOperations712.setConnectorPort: {
       updateConfigPort(
         formState.cr,
         ConfigType.connectors,
@@ -692,14 +753,16 @@ export const reducer712: React.Reducer<
         action.payload.port,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorHost:
+    }
+    case ArtemisReducerOperations712.setConnectorHost: {
       updateConnectorHost(
         formState.cr,
         action.payload.connectorName,
         action.payload.host,
       );
       break;
-    case ArtemisReducerOperations712.setAcceptorBindToAllInterfaces:
+    }
+    case ArtemisReducerOperations712.setAcceptorBindToAllInterfaces: {
       updateConfigBindToAllInterfaces(
         formState.cr,
         ConfigType.acceptors,
@@ -707,7 +770,8 @@ export const reducer712: React.Reducer<
         action.payload.bindToAllInterfaces,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorBindToAllInterfaces:
+    }
+    case ArtemisReducerOperations712.setConnectorBindToAllInterfaces: {
       updateConfigBindToAllInterfaces(
         formState.cr,
         ConfigType.connectors,
@@ -715,7 +779,8 @@ export const reducer712: React.Reducer<
         action.payload.bindToAllInterfaces,
       );
       break;
-    case ArtemisReducerOperations712.setAcceptorProtocols:
+    }
+    case ArtemisReducerOperations712.setAcceptorProtocols: {
       updateConfigProtocols(
         formState.cr,
         ConfigType.acceptors,
@@ -723,7 +788,8 @@ export const reducer712: React.Reducer<
         action.payload.protocols,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorProtocols:
+    }
+    case ArtemisReducerOperations712.setConnectorProtocols: {
       updateConfigProtocols(
         formState.cr,
         ConfigType.connectors,
@@ -731,7 +797,8 @@ export const reducer712: React.Reducer<
         action.payload.protocols,
       );
       break;
-    case ArtemisReducerOperations712.setAcceptorOtherParams:
+    }
+    case ArtemisReducerOperations712.setAcceptorOtherParams: {
       updateConfigOtherParams(
         formState.cr,
         ConfigType.acceptors,
@@ -739,7 +806,8 @@ export const reducer712: React.Reducer<
         action.payload.otherParams,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorOtherParams:
+    }
+    case ArtemisReducerOperations712.setConnectorOtherParams: {
       updateConfigOtherParams(
         formState.cr,
         ConfigType.connectors,
@@ -747,7 +815,8 @@ export const reducer712: React.Reducer<
         action.payload.otherParams,
       );
       break;
-    case ArtemisReducerOperations712.setAcceptorSSLEnabled:
+    }
+    case ArtemisReducerOperations712.setAcceptorSSLEnabled: {
       updateConfigSSLEnabled(
         formState.cr,
         ConfigType.acceptors,
@@ -755,7 +824,8 @@ export const reducer712: React.Reducer<
         action.payload.sslEnabled,
       );
       break;
-    case ArtemisReducerOperations712.setConnectorSSLEnabled:
+    }
+    case ArtemisReducerOperations712.setConnectorSSLEnabled: {
       updateConfigSSLEnabled(
         formState.cr,
         ConfigType.connectors,
@@ -763,7 +833,8 @@ export const reducer712: React.Reducer<
         action.payload.sslEnabled,
       );
       break;
-    case ArtemisReducerOperations712.updateAcceptorFactoryClass:
+    }
+    case ArtemisReducerOperations712.updateAcceptorFactoryClass: {
       updateConfigFactoryClass(
         formState.cr,
         ConfigType.acceptors,
@@ -771,7 +842,8 @@ export const reducer712: React.Reducer<
         action.payload.class,
       );
       break;
-    case ArtemisReducerOperations712.updateConnectorFactoryClass:
+    }
+    case ArtemisReducerOperations712.updateConnectorFactoryClass: {
       updateConfigFactoryClass(
         formState.cr,
         ConfigType.connectors,
@@ -779,7 +851,8 @@ export const reducer712: React.Reducer<
         action.payload.class,
       );
       break;
-    case ArtemisReducerOperations712.setIngressDomain:
+    }
+    case ArtemisReducerOperations712.setIngressDomain: {
       if (typeof action.payload === 'string') {
         updateIngressDomain(formState.cr, action.payload);
       } else {
@@ -787,6 +860,7 @@ export const reducer712: React.Reducer<
         formState.hasChanges = action.payload.isSetByUser;
       }
       break;
+    }
     default:
       throw Error('Unknown action: ' + action);
   }
@@ -801,31 +875,38 @@ const updateAnnotationIssuer = (
   acceptorName: string,
   newIssuer: string,
 ) => {
+  if (!cr.spec) throw new Error('spec should not be undefined');
   if (!cr.spec.resourceTemplates) {
     return;
   }
   const acceptor = getAcceptor(cr, acceptorName);
+  if (!acceptor) return;
   const selector = certManagerSelector(cr, acceptor.name);
   const rt = cr.spec.resourceTemplates.find(
     (rt) => rt.selector?.name === selector,
   );
   if (rt) {
+    if (!rt.annotations) {
+      rt.annotations = {};
+    }
     rt.annotations['cert-manager.io/issuer'] = newIssuer;
   }
 };
 
 const updateIngressDomain = (cr: BrokerCR, newName: string) => {
+  if (!cr.spec) throw new Error('spec should not be undefined');
   cr.spec.ingressDomain = newName;
   // when the namespace changes, some annotations will need an update to
   // stay in sync
   if (!cr.spec.acceptors || !cr.spec.resourceTemplates) {
     return;
   }
+  const resourceTemplates = cr.spec.resourceTemplates;
   cr.spec.acceptors.forEach((acceptor) => {
-    const rt = cr.spec.resourceTemplates.find(
-      (rt) => rt.selector.name === certManagerSelector(cr, acceptor.name),
+    const rt = resourceTemplates.find(
+      (rt) => rt.selector?.name === certManagerSelector(cr, acceptor.name),
     );
-    if (!rt) {
+    if (!rt?.patch?.spec?.tls?.[0]) {
       return;
     }
     rt.patch.spec.tls[0].hosts = certManagerTlsHosts(cr, acceptor.name);
@@ -833,6 +914,14 @@ const updateIngressDomain = (cr: BrokerCR, newName: string) => {
 };
 
 const updateDeploymentSize = (cr: BrokerCR, newSize: number) => {
+  if (!cr.spec) throw new Error('spec should not be undefined');
+  if (!cr.spec.deploymentPlan) {
+    cr.spec.deploymentPlan = {
+      image: 'placeholder',
+      requireLogin: false,
+      size: 1,
+    };
+  }
   cr.spec.deploymentPlan.size = newSize;
   if (cr.spec.deploymentPlan.size < 1) {
     cr.spec.deploymentPlan.size = 0;
@@ -845,11 +934,12 @@ const updateDeploymentSize = (cr: BrokerCR, newSize: number) => {
   if (!cr.spec.resourceTemplates) {
     return;
   }
+  const resourceTemplates = cr.spec.resourceTemplates;
   cr.spec.acceptors.forEach((acceptor) => {
-    const rt = cr.spec.resourceTemplates.find(
-      (rt) => rt.selector.name === certManagerSelector(cr, acceptor.name),
+    const rt = resourceTemplates.find(
+      (rt) => rt.selector?.name === certManagerSelector(cr, acceptor.name),
     );
-    if (!rt) {
+    if (!rt?.patch?.spec?.tls?.[0]) {
       return;
     }
     rt.patch.spec.tls[0].hosts = certManagerTlsHosts(cr, acceptor.name);
@@ -857,6 +947,10 @@ const updateDeploymentSize = (cr: BrokerCR, newSize: number) => {
 };
 
 const updateNamespace = (cr: BrokerCR, newName: string) => {
+  if (!cr.metadata) {
+    cr.metadata = {};
+  }
+  if (!cr.spec) throw new Error('spec should not be undefined');
   cr.metadata.namespace = newName;
   // when the namespace changes, some annotations will need an update to
   // stay in sync
@@ -866,11 +960,12 @@ const updateNamespace = (cr: BrokerCR, newName: string) => {
   if (!cr.spec.resourceTemplates) {
     return;
   }
+  const resourceTemplates = cr.spec.resourceTemplates;
   cr.spec.acceptors.forEach((acceptor) => {
-    const rt = cr.spec.resourceTemplates.find(
-      (rt) => rt.selector.name === certManagerSelector(cr, acceptor.name),
+    const rt = resourceTemplates.find(
+      (rt) => rt.selector?.name === certManagerSelector(cr, acceptor.name),
     );
-    if (!rt) {
+    if (!rt?.patch?.spec?.tls?.[0]) {
       return;
     }
     rt.patch.spec.tls[0].hosts = certManagerTlsHosts(cr, acceptor.name);
@@ -878,6 +973,10 @@ const updateNamespace = (cr: BrokerCR, newName: string) => {
 };
 
 const updateBrokerName = (cr: BrokerCR, newName: string) => {
+  if (!cr.metadata) {
+    cr.metadata = {};
+  }
+  if (!cr.spec) throw new Error('spec should not be undefined');
   const prevBrokerName = cr.metadata.name;
   cr.metadata.name = newName;
   // when the broker name changes, some acceptors & annotations will need an
@@ -889,15 +988,18 @@ const updateBrokerName = (cr: BrokerCR, newName: string) => {
     if (acceptor.sslSecret && acceptor.sslSecret.endsWith('-ptls')) {
       acceptor.sslSecret = certManagerSecret(cr, acceptor.name);
     }
-    if (!cr.spec.resourceTemplates) {
-      return;
-    }
+  });
+  if (!cr.spec.resourceTemplates) {
+    return;
+  }
+  const resourceTemplates = cr.spec.resourceTemplates;
+  cr.spec.acceptors.forEach((acceptor) => {
     const outdatedSelector =
       prevBrokerName + '-' + acceptor.name + '-0-svc-ing';
-    const rt = cr.spec.resourceTemplates.find(
+    const rt = resourceTemplates.find(
       (rt) => rt.selector?.name === outdatedSelector,
     );
-    if (!rt) {
+    if (!rt?.selector || !rt?.patch?.spec?.tls?.[0]) {
       return;
     }
     rt.selector.name = certManagerSelector(cr, acceptor.name);
@@ -918,7 +1020,7 @@ const activatePEMGenerationForAcceptor = (
   acceptorName: string,
 ) => {
   const acceptor = getAcceptor(cr, acceptorName);
-  if (acceptor) {
+  if (acceptor && acceptor.name) {
     acceptor.sslEnabled = true;
     acceptor.expose = true;
     acceptor.exposeMode = ExposeMode.ingress;
@@ -940,6 +1042,7 @@ const setIssuerForAcceptor = (
   if (!acceptor) {
     return;
   }
+  if (!cr.spec) throw new Error('spec should not be undefined');
   // in case there are no resource templates in the CR
   if (!cr.spec.resourceTemplates) {
     cr.spec.resourceTemplates = [];
@@ -951,6 +1054,9 @@ const setIssuerForAcceptor = (
   );
   // either update the existing one or create a new annotation
   if (rt) {
+    if (!rt.annotations) {
+      rt.annotations = {};
+    }
     rt.annotations['cert-manager.io/issuer'] = issuerName;
   } else {
     cr.spec.resourceTemplates.push(
@@ -960,6 +1066,11 @@ const setIssuerForAcceptor = (
 };
 
 const certManagerTlsHosts = (cr: BrokerCR, acceptor: string): string[] => {
+  if (!cr.spec) throw new Error('spec should not be undefined');
+  if (!cr.metadata) throw new Error('metadata should not be undefined');
+  if (!cr.spec.deploymentPlan) {
+    return [];
+  }
   const ret: string[] = [];
   for (let i = 0; i < cr.spec.deploymentPlan.size; i++) {
     ret.push(
@@ -979,11 +1090,15 @@ const certManagerTlsHosts = (cr: BrokerCR, acceptor: string): string[] => {
   return ret;
 };
 
-const certManagerSelector = (cr: BrokerCR, acceptor: string) =>
-  cr.metadata.name + '-' + acceptor + '-0-svc-ing';
+const certManagerSelector = (cr: BrokerCR, acceptor: string): string => {
+  if (!cr.metadata) throw new Error('metadata should not be undefined');
+  return cr.metadata.name + '-' + acceptor + '-0-svc-ing';
+};
 
-const certManagerSecret = (cr: BrokerCR, acceptor: string) =>
-  cr.metadata.name + '-' + acceptor + '-0-svc-ing-ptls';
+const certManagerSecret = (cr: BrokerCR, acceptor: string): string => {
+  if (!cr.metadata) throw new Error('metadata should not be undefined');
+  return cr.metadata.name + '-' + acceptor + '-0-svc-ing-ptls';
+};
 
 /**
  * Updates the acceptor name in the various fields of the annotation matching
@@ -994,6 +1109,7 @@ const updateAcceptorNameInResourceTemplate = (
   prevName: string,
   newName: string,
 ) => {
+  if (!cr.spec) throw new Error('spec should not be undefined');
   // early return if there's no resource template to work on
   if (!cr.spec.resourceTemplates) {
     return;
@@ -1003,7 +1119,7 @@ const updateAcceptorNameInResourceTemplate = (
     (rt) => rt.selector?.name === certManagerSelector(cr, prevName),
   );
   // if there's a match update the required fields
-  if (rt) {
+  if (rt?.selector && rt?.patch?.spec?.tls?.[0]) {
     rt.selector.name = certManagerSelector(cr, newName);
     rt.patch.spec.tls[0].hosts = certManagerTlsHosts(cr, newName);
     rt.patch.spec.tls[0].secretName = certManagerSecret(cr, newName);
@@ -1046,17 +1162,19 @@ const createCertManagerResourceTemplate = (
  * remove the cert manager annotation for a given acceptor if one is found
  */
 const deleteCertManagerAnnotation = (cr: BrokerCR, acceptor: string) => {
+  if (!cr.spec) throw new Error('spec should not be undefined');
+
   if (!cr.spec.resourceTemplates) {
     return;
   }
   cr.spec.resourceTemplates = cr.spec.resourceTemplates.filter(
-    (rt) => rt.selector.name !== certManagerSelector(cr, acceptor),
+    (rt) => rt.selector?.name !== certManagerSelector(cr, acceptor),
   );
 };
 
 const generateUniqueName = (prefix: string, existing: Set<string>): string => {
   const limit = existing.size + 1;
-  let newName;
+  let newName = '';
   for (let i = 0; i < limit; i++) {
     newName = prefix + i;
     if (!existing.has(newName)) {
@@ -1119,6 +1237,8 @@ const addConfig = (cr: BrokerCR, configType: ConfigType) => {
 
   const newName = generateUniqueName(configType, acceptorSet);
 
+  if (!cr.spec) throw new Error('spec should not be undefined');
+
   if (configType === ConfigType.connectors) {
     const connector = {
       name: newName,
@@ -1169,20 +1289,24 @@ const deleteConfig = (
     configType === ConfigType.connectors
       ? 'connectorConfigurations.'
       : 'acceptorConfigurations.';
-  if (brokerModel.spec?.brokerProperties?.length > 0) {
+
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+  if (!brokerModel.spec.brokerProperties) return;
+
+  if (brokerModel.spec.brokerProperties?.length > 0) {
     const configKey = prefix + configName + '.';
     brokerModel.spec.brokerProperties =
       brokerModel.spec.brokerProperties.filter((x: string) => {
         return !x.startsWith(configKey);
       });
     if (configType === ConfigType.connectors) {
-      if (brokerModel.spec?.connectors) {
+      if (brokerModel.spec.connectors) {
         brokerModel.spec.connectors = brokerModel.spec.connectors.filter(
           (connector) => connector.name !== configName,
         );
       }
     } else {
-      if (brokerModel.spec?.acceptors) {
+      if (brokerModel.spec.acceptors) {
         brokerModel.spec.acceptors = brokerModel.spec.acceptors.filter(
           (acceptor) => acceptor.name !== configName,
         );
@@ -1214,7 +1338,11 @@ const renameConfig = (
     configType === ConfigType.connectors
       ? 'connectorConfigurations.'
       : 'acceptorConfigurations.';
-  if (brokerModel.spec?.brokerProperties?.length > 0) {
+
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+  if (!brokerModel.spec.brokerProperties) return;
+
+  if (brokerModel.spec.brokerProperties?.length > 0) {
     const configKey = prefix + previousName + '.';
     const newKey = prefix + newName + '.';
     brokerModel.spec.brokerProperties = brokerModel.spec.brokerProperties.map(
@@ -1227,15 +1355,16 @@ const renameConfig = (
     );
 
     if (configType === ConfigType.connectors) {
-      if (brokerModel.spec?.connectors?.length > 0) {
-        brokerModel.spec.connectors = brokerModel.spec.connectors.map(
-          (o: { name: string }) => {
-            if (o.name === previousName) {
-              return { ...o, name: newName };
-            }
-            return o;
-          },
-        );
+      if (
+        brokerModel.spec.connectors &&
+        brokerModel.spec.connectors.length > 0
+      ) {
+        brokerModel.spec.connectors = brokerModel.spec.connectors.map((o) => {
+          if (o.name === previousName) {
+            return { ...o, name: newName };
+          }
+          return o;
+        });
       }
     }
     if (configType === ConfigType.acceptors) {
@@ -1256,12 +1385,14 @@ const renameConfig = (
 const updateConfigSecret = (
   brokerModel: BrokerCR,
   configType: ConfigType,
-  secret: string,
+  secret: string | undefined,
   configName: string,
   isCa: boolean,
 ) => {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+
   if (configType === ConfigType.connectors) {
-    if (brokerModel.spec?.connectors?.length > 0) {
+    if (brokerModel.spec.connectors && brokerModel.spec.connectors.length > 0) {
       for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
         if (brokerModel.spec.connectors[i].name === configName) {
           if (isCa) {
@@ -1287,7 +1418,7 @@ const updateConfigSecret = (
       }
     }
   } else if (configType === ConfigType.acceptors) {
-    if (brokerModel.spec?.acceptors?.length > 0) {
+    if (brokerModel.spec.acceptors && brokerModel.spec.acceptors.length > 0) {
       for (let i = 0; i < brokerModel.spec.acceptors.length; i++) {
         if (brokerModel.spec.acceptors[i].name === configName) {
           if (isCa) {
@@ -1313,7 +1444,7 @@ const updateConfigSecret = (
       }
     }
   } else {
-    if (brokerModel.spec?.console) {
+    if (brokerModel.spec.console) {
       if (isCa) {
         if (secret) {
           if (!brokerModel.spec.console.trustSecret) {
@@ -1341,8 +1472,10 @@ const updateConfigPort = (
   configName: string,
   port: number,
 ): void => {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+
   if (configType === ConfigType.connectors) {
-    if (brokerModel.spec?.connectors?.length > 0) {
+    if (brokerModel.spec.connectors && brokerModel.spec.connectors.length > 0) {
       for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
         if (brokerModel.spec.connectors[i].name === configName) {
           brokerModel.spec.connectors[i].port = port;
@@ -1350,7 +1483,7 @@ const updateConfigPort = (
       }
     }
   } else {
-    if (brokerModel.spec?.acceptors?.length > 0) {
+    if (brokerModel.spec.acceptors && brokerModel.spec.acceptors.length > 0) {
       for (let i = 0; i < brokerModel.spec.acceptors.length; i++) {
         if (brokerModel.spec.acceptors[i].name === configName) {
           brokerModel.spec.acceptors[i].port = port;
@@ -1365,7 +1498,10 @@ const updateConnectorHost = (
   connectorName: string,
   host: string,
 ): void => {
-  if (brokerModel.spec?.connectors?.length > 0) {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+  if (!brokerModel.spec.connectors) return;
+
+  if (brokerModel.spec.connectors.length > 0) {
     for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
       if (brokerModel.spec.connectors[i].name === connectorName) {
         brokerModel.spec.connectors[i].host = host;
@@ -1380,9 +1516,11 @@ const updateConfigBindToAllInterfaces = (
   configName: string,
   bindToAllInterfaces: boolean,
 ): void => {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
   if (
     configType === ConfigType.acceptors &&
-    brokerModel.spec?.acceptors?.length > 0
+    brokerModel.spec.acceptors &&
+    brokerModel.spec.acceptors.length > 0
   ) {
     for (let i = 0; i < brokerModel.spec.acceptors.length; i++) {
       if (brokerModel.spec.acceptors[i].name === configName) {
@@ -1392,7 +1530,8 @@ const updateConfigBindToAllInterfaces = (
   }
   if (
     configType === ConfigType.connectors &&
-    brokerModel.spec?.connectors?.length > 0
+    brokerModel.spec.connectors &&
+    brokerModel.spec.connectors.length > 0
   ) {
     for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
       if (brokerModel.spec.connectors[i].name === configName) {
@@ -1409,8 +1548,9 @@ const updateConfigProtocols = (
   configName: string,
   protocols: string,
 ): void => {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
   if (configType === ConfigType.connectors) {
-    if (brokerModel.spec?.connectors?.length > 0) {
+    if (brokerModel.spec.connectors && brokerModel.spec.connectors.length > 0) {
       for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
         if (brokerModel.spec.connectors[i].name === configName) {
           brokerModel.spec.connectors[i].protocols = protocols;
@@ -1418,7 +1558,7 @@ const updateConfigProtocols = (
       }
     }
   } else {
-    if (brokerModel.spec?.acceptors?.length > 0) {
+    if (brokerModel.spec.acceptors && brokerModel.spec.acceptors.length > 0) {
       for (let i = 0; i < brokerModel.spec.acceptors.length; i++) {
         if (brokerModel.spec.acceptors[i].name === configName) {
           brokerModel.spec.acceptors[i].protocols = protocols;
@@ -1446,7 +1586,11 @@ const updateConfigOtherParams = (
   };
   //const paramSet = new Set<string>(otherParams.split(','));
   const paramPrefix = getConfigParamKey(configType, configName);
-  if (brokerModel.spec?.brokerProperties?.length > 0) {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+  if (!brokerModel.spec.brokerProperties) {
+    brokerModel.spec.brokerProperties = [];
+  }
+  if (brokerModel.spec.brokerProperties.length > 0) {
     //update
     for (let i = 0; i < brokerModel.spec.brokerProperties.length; i++) {
       if (brokerModel.spec.brokerProperties[i].startsWith(paramPrefix)) {
@@ -1475,7 +1619,7 @@ const updateConfigOtherParams = (
   }
   //now new params
   paramMap.forEach((v, k) => {
-    brokerModel.spec.brokerProperties.push(paramPrefix + k + '=' + v);
+    brokerModel.spec!.brokerProperties!.push(paramPrefix + k + '=' + v);
   });
 };
 
@@ -1485,8 +1629,9 @@ const updateConfigSSLEnabled = (
   configName: string,
   isSSLEnabled: boolean,
 ): void => {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
   if (configType === ConfigType.connectors) {
-    if (brokerModel.spec?.connectors?.length > 0) {
+    if (brokerModel.spec.connectors && brokerModel.spec.connectors.length > 0) {
       for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
         if (brokerModel.spec.connectors[i].name === configName) {
           brokerModel.spec.connectors[i].sslEnabled = isSSLEnabled;
@@ -1518,7 +1663,9 @@ const updateConfigSSLEnabled = (
 
 const clearAcceptorCertManagerConfig = (cr: BrokerCR, name: string) => {
   const acceptor = getAcceptor(cr, name);
-  if (acceptor.sslSecret && acceptor.sslSecret.endsWith('-ptls')) {
+  if (!acceptor) return;
+
+  if (acceptor.sslSecret?.endsWith('-ptls')) {
     deleteCertManagerAnnotation(cr, acceptor.name);
     delete acceptor.sslEnabled;
     delete acceptor.sslSecret;
@@ -1526,9 +1673,9 @@ const clearAcceptorCertManagerConfig = (cr: BrokerCR, name: string) => {
     delete acceptor.exposeMode;
     delete acceptor.ingressHost;
   }
-  if (!cr.spec.resourceTemplates) {
-    return;
-  }
+  if (!cr.spec) throw new Error('spec should not be undefined');
+  if (!cr.spec.resourceTemplates) return;
+
   if (cr.spec.resourceTemplates.length === 0) {
     delete cr.spec.resourceTemplates;
   }
@@ -1546,6 +1693,10 @@ const updateConfigFactoryClass = (
     }
     return 'acceptorConfigurations.';
   };
+
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+  if (!brokerModel.spec.brokerProperties) return;
+
   for (let i = 0; i < brokerModel.spec.brokerProperties.length; i++) {
     const configPrefix = getConfigPrefix(configType);
     if (brokerModel.spec.brokerProperties[i].startsWith(configPrefix)) {
@@ -1605,6 +1756,10 @@ export const getConfigSecret = (
     }
   }
   if (configType === ConfigType.console) {
+    if (!brokerModel.spec) throw new Error('spec should not be undefined');
+    if (!brokerModel.spec.console)
+      throw new Error('console should not be undefined');
+
     if (isCa) {
       if (brokerModel.spec.console.trustSecret) {
         return brokerModel.spec.console.trustSecret;
@@ -1621,7 +1776,12 @@ export const getConfigFactoryClass = (
   configType: ConfigType,
   configName: string,
 ): string => {
-  if (brokerModel.spec?.brokerProperties?.length > 0) {
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
+
+  if (
+    brokerModel.spec.brokerProperties &&
+    brokerModel.spec.brokerProperties.length > 0
+  ) {
     for (let i = 0; i < brokerModel.spec.brokerProperties.length; i++) {
       const prefix =
         configType === ConfigType.connectors
@@ -1667,7 +1827,7 @@ export const getAcceptorFromCertManagerResourceTemplate = (
 ) => {
   if (cr.spec?.acceptors) {
     return cr.spec.acceptors.find((acceptor) => {
-      if (acceptor.sslSecret === rt.patch.spec.tls[0].secretName) {
+      if (acceptor.sslSecret === rt.patch?.spec?.tls?.[0]?.secretName) {
         return acceptor;
       }
       return undefined;
@@ -1685,7 +1845,7 @@ export const getCertManagerResourceTemplateFromAcceptor = (
   }
   if (cr.spec?.resourceTemplates) {
     return cr.spec.resourceTemplates.find((rt) => {
-      if (rt.patch.spec.tls[0].secretName === acceptor.sslSecret) {
+      if (rt.patch?.spec?.tls?.[0]?.secretName === acceptor.sslSecret) {
         return acceptor;
       }
       return undefined;
@@ -1722,7 +1882,7 @@ export const getConfigPort = (
       return connector.port;
     }
   }
-  return undefined;
+  throw new Error(`port not found for ${configType} config '${configName}'`);
 };
 
 export const getConfigHost = (
@@ -1799,7 +1959,11 @@ export const getConfigOtherParams = (
   configName: string,
 ): Map<string, string> => {
   const ret = new Map<string, string>();
-  if (cr.spec?.brokerProperties?.length > 0) {
+  if (
+    cr.spec &&
+    cr.spec.brokerProperties &&
+    cr.spec.brokerProperties.length > 0
+  ) {
     const paramKey = getConfigParamKey(configType, configName);
     const portKey = paramKey + 'port=';
     const protocolsKey = paramKey + 'protocols=';
@@ -1825,16 +1989,19 @@ export const listConfigs = (
   resultType?: 'set' | 'list',
 ): { name: string }[] | Set<string> => {
   const acceptors = new Set<string>();
+  if (!brokerModel.spec) throw new Error('spec should not be undefined');
   if (configType === ConfigType.connectors) {
-    if (brokerModel.spec?.connectors?.length > 0) {
+    if (brokerModel.spec.connectors && brokerModel.spec.connectors.length > 0) {
       for (let i = 0; i < brokerModel.spec.connectors.length; i++) {
-        acceptors.add(brokerModel.spec.connectors[i].name);
+        const name = brokerModel.spec.connectors[i].name;
+        if (name) acceptors.add(name);
       }
     }
   } else {
-    if (brokerModel.spec?.acceptors?.length > 0) {
+    if (brokerModel.spec.acceptors && brokerModel.spec.acceptors.length > 0) {
       for (let i = 0; i < brokerModel.spec.acceptors.length; i++) {
-        acceptors.add(brokerModel.spec.acceptors[i].name);
+        const name = brokerModel.spec.acceptors[i].name;
+        if (name) acceptors.add(name);
       }
     }
   }
@@ -1874,6 +2041,7 @@ export const getIssuerForAcceptor = (cr: BrokerCR, acceptor: Acceptor) => {
   if (!acceptor) {
     return '';
   }
+  if (!cr.spec) throw new Error('spec should not be undefined');
   // in case there are no resource templates in the CR
   if (!cr.spec.resourceTemplates) {
     cr.spec.resourceTemplates = [];
@@ -1884,7 +2052,7 @@ export const getIssuerForAcceptor = (cr: BrokerCR, acceptor: Acceptor) => {
     (rt) => rt.selector?.name === selector,
   );
   if (rt) {
-    return rt.annotations['cert-manager.io/issuer'];
+    return rt.annotations?.['cert-manager.io/issuer'] ?? '';
   }
   return '';
 };
@@ -1896,6 +2064,7 @@ export const isMissingIssuer = (cr: BrokerCR, acceptor: Acceptor) => {
   if (!acceptor) {
     return false;
   }
+  if (!cr.spec) throw new Error('spec should not be undefined');
   // in case there are no resource templates in the CR
   if (!cr.spec.resourceTemplates) {
     return false;
@@ -1906,7 +2075,7 @@ export const isMissingIssuer = (cr: BrokerCR, acceptor: Acceptor) => {
     (rt) => rt.selector?.name === selector,
   );
   if (rt) {
-    return !rt.annotations['cert-manager.io/issuer'];
+    return !rt.annotations?.['cert-manager.io/issuer'];
   }
   return false;
 };
@@ -1919,6 +2088,7 @@ export const getIssuerIngressHostForAcceptor = (
   if (!acceptor) {
     return '';
   }
+  if (!cr.spec) throw new Error('spec should not be undefined');
   // in case there are no resource templates in the CR
   if (!cr.spec.resourceTemplates) {
     cr.spec.resourceTemplates = [];
@@ -1928,7 +2098,7 @@ export const getIssuerIngressHostForAcceptor = (
   const rt = cr.spec.resourceTemplates.find(
     (rt) => rt.selector?.name === selector,
   );
-  if (rt) {
+  if (rt?.patch?.spec?.tls?.[0]?.hosts) {
     return rt.patch.spec.tls[0].hosts[podOrdinal];
   }
   return '';
@@ -1938,16 +2108,15 @@ export const areMandatoryValuesSet712 = (formState: FormState712) => {
   if (!formState.cr?.metadata?.name) {
     return false;
   }
+  const cr = formState.cr;
   // check that every acceptor sets the required fields
-  if (formState.cr.spec?.acceptors && formState.cr.spec.acceptors.length > 0) {
-    const allAceptorOk = formState.cr.spec.acceptors
+  if (cr.spec?.acceptors && cr.spec.acceptors.length > 0) {
+    const allAceptorOk = cr.spec.acceptors
       .map((acceptor) => {
         const missingPort = !acceptor.port;
         const missingProtocols = !acceptor.protocols;
         return (
-          !missingPort &&
-          !missingProtocols &&
-          !isMissingIssuer(formState.cr, acceptor)
+          !missingPort && !missingProtocols && !isMissingIssuer(cr, acceptor)
         );
       })
       .reduce((acc, next) => acc && next);
@@ -1956,11 +2125,8 @@ export const areMandatoryValuesSet712 = (formState: FormState712) => {
     }
   }
   // check that every connector sets the required fields
-  if (
-    formState.cr.spec?.connectors &&
-    formState.cr.spec.connectors.length > 0
-  ) {
-    const allConnectorOk = formState.cr.spec.connectors
+  if (cr.spec?.connectors && cr.spec.connectors.length > 0) {
+    const allConnectorOk = cr.spec.connectors
       .map((connector) => {
         const missingHostname = !connector.host;
         const missingPort = !connector.port;

--- a/src/reducers/7.12/tsconfig.json
+++ b/src/reducers/7.12/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "composite": false
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
Fixes: [issue#170](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/170)