### PR TITLE
Remove restricted mode as the default broker creation mode

### DIFF
--- a/playwright/e2e/smoke.spec.ts
+++ b/playwright/e2e/smoke.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../fixtures/auth';
-import { toggleRestrictedMode } from '../fixtures/restrictedMode';
 
 const username = 'kubeadmin';
 const password = process.env.KUBEADMIN_PASSWORD || 'kubeadmin';
@@ -37,10 +36,6 @@ test.describe('Create Broker via UI', () => {
       .first();
     await createBrokerButton.scrollIntoViewIfNeeded();
     await createBrokerButton.click();
-
-    // Disable restricted mode first (form now defaults to restricted mode)
-    // This needs to be done BEFORE filling the name, as switching modes resets the form
-    await toggleRestrictedMode(page, false);
 
     // NOW fill CR Name with a unique value (after switching modes)
     const brokerName = `e2e-broker-${Date.now()}`;

--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -14,7 +14,6 @@ import { ArtemisReducerOperations712 } from '@app/reducers/7.12/reducer';
 import { FormState712 } from '@app/reducers/7.12/import-types';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useGetIngressDomain } from '@app/k8s/customHooks';
-import { ArtemisReducerOperationsRestricted } from '@app/reducers/restricted/reducer';
 
 export interface AddBrokerProps {
   initialValues: FormState712;
@@ -78,11 +77,6 @@ export const AddBrokerPage: FC = () => {
         ingressUrl: clusterDomain,
         isSetByUser: false,
       },
-    });
-    // Restricted is the new default
-    dispatch({
-      operation: ArtemisReducerOperationsRestricted.setIsRestrited,
-      payload: true,
     });
     setIsDomainSet(true);
   }


### PR DESCRIPTION
Removed restricted mode as the default broker creation mode.

<img width="1919" height="1077" alt="Screenshot From 2026-03-03 14-24-02" src="https://github.com/user-attachments/assets/1dd73de2-b963-4c38-ba34-c8984936e5ad" />

fixes: [issue#185](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/185)