### PR TITLE
 fix CI: prevent typecheck:7.12 from failing on unrelated type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,14 @@ jobs:
         run: yarn i18n && git diff --exit-code locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
 
       - name: check strict mode for reducers/7.12
-        run: yarn typecheck:7.12 2>&1 | grep "src/reducers/7.12/" && exit 1 || echo ok
+        run: |
+          OUTPUT=$(yarn typecheck:7.12 2>&1 || true)
+          if echo "$OUTPUT" | grep -q "src/reducers/7.12/"; then
+            echo "$OUTPUT"
+            exit 1
+          else
+            echo ok
+          fi
 
       - name: Build project
         run: yarn run build


### PR DESCRIPTION
GitHub Actions enables pipefail by default, causing the typecheck:7.12 step to fail when tsc finds errors in files outside src/reducers/7.12/. Disabling pipefail allows the grep filter to work as intended.

fixes: [issue#187](https://github.com/arkmq-org/activemq-artemis-self-provisioning-plugin/issues/187)